### PR TITLE
feat: add 'publications and talks' section

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,5 +9,8 @@
         "eslint-config-moxy/addons/es6-modules",
         "eslint-config-moxy/addons/react",
         "eslint-config-moxy/addons/jest"
-    ]
+    ],
+    "rules": {
+        "no-invalid-this": 0
+    }
 }

--- a/intl/messages/en.json
+++ b/intl/messages/en.json
@@ -56,5 +56,11 @@
     "whatPeopleAreBuildingTitle": "What are people building with it",
     "whatPeopleAreBuildingSectionDesc": "Maecenas sed eu leo. s eget urna mollis ornare vel eu leo diam eget risus varius blaecenas sed diam eget risus varius blandit sit amet non magna. Lorem ipsum dolor sit amet.",
     "whatArePeopleBuildingProj1Desc": "Maecenas faucibus mollis interd. Donec id elit non mi porta gravida eget metus. Nullam id dolor id nib ultricies vehicula ut id elit.",
+    "publicationsAndTalksTitle": "Publications & talks",
+    "publicationsAndTalksSectionDesc": "Nullam quis risus eget  urna mollis ornare vel eu leo. Maecenas sed diam eget risus varius magna. Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    "publicationAndTalk1Desc": "Nullam id dolor id nib ultricies vehicula ut id elit.",
+    "publicationAndTalk2Desc": "Maecenas faucibus mollis interd. Donec id elit non mi porta gravida eget metus. Donec id elit non mi porta gravida eget metus. Donec id elit non mi porta gravida eget metus.",
+    "publicationAndTalk3Desc": "Maecenas faucibus mollis iterdum. Curabitur blandit tempus porttitor.",
+    "publicationAndTalk4Desc": "Nullam id dolor id elit non mi porta mollis ornare vel eu leo.",
     "service-worker": "Enable Service Worker"
 }

--- a/intl/messages/pt.json
+++ b/intl/messages/pt.json
@@ -38,5 +38,11 @@
     "whatPeopleAreBuildingTitle": "Lorem ipsum",
     "whatPeopleAreBuildingSectionDesc": "PT-Maecenas sed eu leo. s eget urna mollis ornare vel eu leo diam eget risus varius blaecenas sed diam eget risus varius blandit sit amet non magna. Lorem ipsum dolor sit amet.",
     "whatArePeopleBuildingProj1Desc": "PT-Maecenas faucibus mollis interd. Donec id elit non mi porta gravida eget metus. Nullam id dolor id nib ultricies vehicula ut id elit.",
+    "publicationsAndTalksTitle": "PT-Publications & talks",
+    "publicationsAndTalksSectionDesc": "PT-Nullam quis risus eget  urna mollis ornare vel eu leo. Maecenas sed diam eget risus varius magna. Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    "publicationAndTalk1Desc": "PT-Nullam id dolor id nib ultricies vehicula ut id elit.",
+    "publicationAndTalk2Desc": "PT-Maecenas faucibus mollis interd. Donec id elit non mi porta gravida eget metus.",
+    "publicationAndTalk3Desc": "PT-Maecenas faucibus mollis iterdum. Curabitur blandit tempus porttitor.",
+    "publicationAndTalk4Desc": "PT-Nullam id dolor id elit non mi porta mollis ornare vel eu leo.",
     "service-worker": "Iniciar Service Worker"
 }

--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -6,6 +6,7 @@ import Features from 'shared/components/features-section';
 import GettingStarted from 'shared/components/getting-started-section';
 import WhatCanYouBuild from 'shared/components/what-can-you-build-section';
 import WhatArePeopleBuilding from 'shared/components/what-are-people-building-section';
+import PublicationsAndTalks from 'shared/components/publications-and-talks-section';
 import styles from './index.module.css';
 
 import { register, unregister } from 'shared/service-worker/register';
@@ -24,6 +25,7 @@ class Home extends Component {
                 <GettingStarted />
                 <WhatCanYouBuild />
                 <WhatArePeopleBuilding />
+                <PublicationsAndTalks />
                 <div>
                     <button onClick={ this.handleServiceWorkerClick }>
                         <FormattedMessage id="service-worker" />

--- a/src/shared/components/carousel/carousel-item/index.module.css
+++ b/src/shared/components/carousel/carousel-item/index.module.css
@@ -42,7 +42,7 @@
                 margin-top: 15px;
                 font-size: var(--typography-text-size-small);
                 text-align: left;
-                line-height: 24px;
+                line-height: var(--line-height-small);
                 letter-spacing: -0.1px;
             }
         }

--- a/src/shared/components/features-section/feature-item/index.module.css
+++ b/src/shared/components/features-section/feature-item/index.module.css
@@ -34,13 +34,13 @@
     & .title {
         font-size: var(--typography-text-size);
         font-weight: var(--typography-text-weight-bold);
-        line-height: 24px;
+        line-height: var(--line-height-small);
     }
 
     & .description {
         font-size: var(--typography-text-size-small);
         font-weight: var(--typography-text-weight);
-        line-height: 21px;
+        line-height: var(--line-height-xsmall);
     }
 }
 

--- a/src/shared/components/getting-started-section/index.module.css
+++ b/src/shared/components/getting-started-section/index.module.css
@@ -40,7 +40,7 @@
         & h1 {
             font-weight: var(--typography-text-weight-bold);
             text-align: center;
-            line-height: 48px;
+            line-height: var(--line-height-large);
         }
 
         & .sectionDescription {
@@ -51,7 +51,7 @@
                 width: 60%;
                 font-size: var(--typography-text-size);
                 font-weight: var(--typography-text-weight);
-                line-height: 27px;
+                line-height: var(--line-height-medium);
             }
         }
 

--- a/src/shared/components/getting-started-section/steps-list/index.module.css
+++ b/src/shared/components/getting-started-section/steps-list/index.module.css
@@ -14,11 +14,11 @@
     }
 
     & .desc {
-        line-height: 1.5;
+        line-height: var(--line-height-small);
     }
 
     & .note {
         margin-top: 15px;
-        line-height: 1.5;
+        line-height: var(--line-height-small);
     }
 }

--- a/src/shared/components/hero-section/index.module.css
+++ b/src/shared/components/hero-section/index.module.css
@@ -29,14 +29,14 @@
         & h1 {
             font-weight: var(--typography-text-weight-bold);
             text-align: center;
-            line-height: 48px;
+            line-height: var(--line-height-large);
         }
 
         & p {
             font-size: var(--typography-text-size);
             font-weight: var(--typography-text-weight-light);
             text-align: center;
-            line-height: 27px;
+            line-height: var(--line-height-medium);
         }
 
         & .infoContainer {

--- a/src/shared/components/locales-dropdown/index.js
+++ b/src/shared/components/locales-dropdown/index.js
@@ -17,9 +17,6 @@ class LocalesDropdown extends Component {
 
         this.availableLocales = localesConfig.availableLocales;
         this.currentLocale = props.intl.locale;
-
-        this.handleToggleDropdown = this.handleToggleDropdown.bind(this);
-        this.handleOutsideClick = this.handleOutsideClick.bind(this);
     }
 
     componentDidMount() {
@@ -68,13 +65,13 @@ class LocalesDropdown extends Component {
         );
     }
 
-    handleToggleDropdown() {
+    handleToggleDropdown = () => {
         this.setState({
             isOpen: !this.state.isOpen,
         });
     }
 
-    handleOutsideClick(event) {
+    handleOutsideClick = (event) => {
         const btnClass = `.${styles.dropButton}`;
 
         if (!event.target.matches(btnClass) && this.state.isOpen) {

--- a/src/shared/components/navbar/desktop/index.js
+++ b/src/shared/components/navbar/desktop/index.js
@@ -15,8 +15,6 @@ class DesktopNavbar extends Component {
         this.state = {
             scrolled: false,
         };
-
-        this.handleScroll = this.handleScroll.bind(this);
     }
 
     componentDidMount() {
@@ -54,7 +52,7 @@ class DesktopNavbar extends Component {
         );
     }
 
-    handleScroll() {
+    handleScroll = () => {
         const scrollY = window.scrollY;
 
         if (scrollY > 50 && !this.state.scrolled) {

--- a/src/shared/components/navbar/mobile/index.js
+++ b/src/shared/components/navbar/mobile/index.js
@@ -16,10 +16,6 @@ class MobileNavbar extends Component {
             isOpen: false,
             scrolled: false,
         };
-
-        this.handleScroll = this.handleScroll.bind(this);
-        this.handleMenuClick = this.handleMenuClick.bind(this);
-        this.handleMenuListRef = this.handleMenuListRef.bind(this);
     }
 
     componentDidMount() {
@@ -68,7 +64,7 @@ class MobileNavbar extends Component {
         );
     }
 
-    handleScroll() {
+    handleScroll = () => {
         const scrollY = window.scrollY;
 
         if (scrollY > 30 && !this.state.scrolled) {
@@ -82,11 +78,11 @@ class MobileNavbar extends Component {
         }
     }
 
-    handleMenuClick() {
+    handleMenuClick = () => {
         this.setState(({ isOpen }) => ({ isOpen: !isOpen }));
     }
 
-    handleMenuListRef(element) {
+    handleMenuListRef = (element) => {
         this.menuListElem = element;
     }
 }

--- a/src/shared/components/publications-and-talks-section/index.js
+++ b/src/shared/components/publications-and-talks-section/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import HexSvg from 'shared/media/backgrounds/hexagons.svg';
+import videosArr from 'shared/data/publications-and-talks';
+import VideosList from 'shared/components/publications-and-talks-section/videos-list';
+import styles from './index.module.css';
+
+const PublicationsAndTalks = () => (
+    <div className={ styles.container }>
+        <div className={ styles.backgroundSvg }>
+            <div className={ styles.hex1 }><HexSvg /></div>
+            <div className={ styles.hex2 }><HexSvg /></div>
+        </div>
+        <div className={ styles.content } >
+            <FormattedMessage tagName="h1" id="publicationsAndTalksTitle" />
+            <span className={ styles.sectionDescription }>
+                <FormattedMessage tagName="p" id="publicationsAndTalksSectionDesc" />
+            </span>
+            <VideosList list={ videosArr } />
+        </div>
+    </div>
+);
+
+export default PublicationsAndTalks;

--- a/src/shared/components/publications-and-talks-section/index.module.css
+++ b/src/shared/components/publications-and-talks-section/index.module.css
@@ -8,8 +8,37 @@
     background: var(--color-white);
     color: var(--color-dark-blue);
 
+    & .backgroundSvg {
+        position: absolute;
+        width: 100%;
+        height: 300px;
+        z-index: 1;
+        display: flex;
+        justify-content: space-between;
+
+        & .hex1,
+        & .hex2 {
+            width: 20%;
+            height: 100%;
+            fill: var(--color-hex-svg-fill);
+        }
+
+        & .hex1 {
+            margin-top: 30%;
+            margin-left: -7%;
+            transform: rotate(180deg);
+        }
+
+        & .hex2 {
+            margin-top: 2%;
+            margin-right: 2%;
+            transform: rotate(180deg);
+        }
+    }
+
     & .content {
         width: var(--container-width);
+        z-index: 2;
         padding: 10% 0;
         display: flex;
         flex-direction: column;
@@ -33,18 +62,17 @@
                 line-height: var(--line-height-medium);
             }
         }
-
-        & .featuresContainer {
-            margin-top: 5%;
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: center;
-        }
     }
 }
 
 @media (--layout-lte-small) {
-    .container .content .sectionDescription p {
-        width: 90%;
+    .container {
+        & .backgroundSvg {
+            display: none;
+        }
+
+        & .content .sectionDescription p {
+            width: 90%;
+        }
     }
 }

--- a/src/shared/components/publications-and-talks-section/videos-list/index.js
+++ b/src/shared/components/publications-and-talks-section/videos-list/index.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import ReactPlayer from 'react-player';
+import PropTypes from 'prop-types';
+
+import RemainingVideo from 'shared/components/publications-and-talks-section/videos-list/remaining-video';
+import styles from './index.module.css';
+
+class VideosList extends Component {
+    constructor(props) {
+        super(props);
+
+        const { list } = props;
+        const activeIndex = list.findIndex(this.findActiveVideo);
+
+        this.state = { activeIndex };
+    }
+
+    render() {
+        return (
+            <div className={ styles.talksContainer }>
+                { this.renderActiveVideo() }
+                <div className={ styles.remainingVideosContainer }>
+                    { this.renderRemainingVideos() }
+                </div>
+            </div>
+        );
+    }
+
+    renderActiveVideo = () => {
+        const { activeIndex } = this.state;
+        const { list } = this.props;
+        const activeVideo = list[activeIndex];
+
+        return (
+            <div className={ styles.selectedVideo }>
+                <ReactPlayer
+                    className={ styles.reactPlayer }
+                    url={ activeVideo.link }
+                    width="100%"
+                    height="100%" />
+            </div>
+        );
+    }
+
+    renderRemainingVideos = () => {
+        const { list } = this.props;
+        const { activeIndex } = this.state;
+
+        return list.map((video, index) => (
+            index !== activeIndex &&
+                <RemainingVideo video={ video } key={ `video-${index}` } index={ index } onClick={ this.handleRemainingVideoClick } />
+        ));
+    }
+
+    findActiveVideo = (video) => !!video.active
+
+    handleRemainingVideoClick = (activeIndex) => {
+        this.setState({ activeIndex });
+    }
+}
+
+VideosList.propTypes = {
+    list: PropTypes.array.isRequired,
+};
+
+export default VideosList;

--- a/src/shared/components/publications-and-talks-section/videos-list/index.module.css
+++ b/src/shared/components/publications-and-talks-section/videos-list/index.module.css
@@ -1,0 +1,51 @@
+@import "shared/styles/imports/variables.css";
+@import "shared/styles/imports/custom-medias.css";
+
+:root {
+    --player-border-radius: 10px;
+}
+
+.talksContainer {
+    width: 70%;
+    margin-top: 5%;
+    display: flex;
+    flex-direction: column;
+
+    & .selectedVideo {
+        position: relative;
+        overflow: hidden;
+        padding-top: var(--video-ratio);
+        border-radius: var(--player-border-radius);
+
+        & .reactPlayer {
+            position: absolute;
+            top: 0;
+            left: 0;
+        }
+    }
+
+    & .remainingVideosContainer {
+        margin-top: 50px;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+    }
+}
+
+@media (--layout-lte-small) {
+    .talksContainer {
+        width: 85%;
+
+        & .remainingVideosContainer {
+            flex-wrap: nowrap;
+            flex-direction: column;
+            align-items: center;
+        }
+    }
+}
+
+@media (--layout-lte-xsmall) {
+    .talksContainer {
+        width: 100%;
+    }
+}

--- a/src/shared/components/publications-and-talks-section/videos-list/remaining-video/index.js
+++ b/src/shared/components/publications-and-talks-section/videos-list/remaining-video/index.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import { injectIntl } from 'react-intl';
+import ReactPlayer from 'react-player';
+import PropTypes from 'prop-types';
+
+import styles from './index.module.css';
+
+class RemainingVideo extends Component {
+    render() {
+        const { video, intl: { messages } } = this.props;
+
+        return (
+            <div className={ styles.videoItemContainer } onClick={ this.handleRemainingVideoClick }>
+                <div className={ styles.videoPlaceholder }>
+                    <ReactPlayer
+                        className={ styles.reactPlayer }
+                        url={ video.link }
+                        width="100%"
+                        height="100%" />
+                </div>
+                <p className={ styles.videoDescription }>{ messages[video.description] }</p>
+            </div>
+        );
+    }
+
+    handleRemainingVideoClick = () => {
+        const { index } = this.props;
+
+        return this.props.onClick(index);
+    }
+}
+
+RemainingVideo.propTypes = {
+    video: PropTypes.object.isRequired,
+    index: PropTypes.number.isRequired,
+    onClick: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+};
+
+export default injectIntl(RemainingVideo);

--- a/src/shared/components/publications-and-talks-section/videos-list/remaining-video/index.module.css
+++ b/src/shared/components/publications-and-talks-section/videos-list/remaining-video/index.module.css
@@ -1,0 +1,54 @@
+@import "shared/styles/imports/variables.css";
+@import "shared/styles/imports/custom-medias.css";
+
+:root {
+    --player-border-radius: 3px;
+}
+
+.videoItemContainer {
+    width: 32%;
+    display: flex;
+    flex-direction: column;
+
+    & .videoPlaceholder,
+    & .videoDescription {
+        width: 100%;
+    }
+
+    & .videoPlaceholder {
+        position: relative;
+        overflow: hidden;
+        padding-top: var(--video-ratio);
+        border-radius: var(--player-border-radius);
+        transition: opacity var(--transition-default-duration) ease;
+
+        &:hover {
+            opacity: 0.7;
+            cursor: pointer;
+        }
+
+        & .reactPlayer {
+            position: absolute;
+            top: 0;
+            left: 0;
+            pointer-events: none;
+        }
+    }
+
+    & .videoDescription {
+        margin-top: 20px;
+        text-align: left;
+        line-height: var(--line-height-small);
+        letter-spacing: -0.1px;
+    }
+}
+
+@media (--layout-lte-small) {
+    .videoItemContainer {
+        width: 80%;
+
+        & .videoDescription {
+            margin-top: 5px;
+        }
+    }
+}

--- a/src/shared/components/what-are-people-building-section/index.module.css
+++ b/src/shared/components/what-are-people-building-section/index.module.css
@@ -46,7 +46,7 @@
         & h1 {
             font-weight: var(--typography-text-weight-bold);
             text-align: center;
-            line-height: 48px;
+            line-height: var(--line-height-large);
         }
 
         & .sectionDescription {
@@ -57,14 +57,21 @@
                 width: 60%;
                 font-size: var(--typography-text-size);
                 font-weight: var(--typography-text-weight);
-                line-height: 27px;
+                line-height: var(--line-height-medium);
             }
         }
     }
 }
 
 @media (--layout-lte-small) {
-    .container .backgroundSvg {
-        display: none;
+    .container {
+        & .backgroundSvg {
+            display: none;
+        }
+
+        & .content .sectionDescription p {
+            width: 90%;
+        }
     }
+
 }

--- a/src/shared/components/what-can-you-build-section/accordion/accordion-item/index.js
+++ b/src/shared/components/what-can-you-build-section/accordion/accordion-item/index.js
@@ -8,12 +8,6 @@ import Button from 'shared/components/button';
 import styles from './index.module.css';
 
 class AccordionItem extends Component {
-    constructor(props) {
-        super(props);
-
-        this.handleButtonClick = this.handleButtonClick.bind(this);
-        this.handlePanelRef = this.handlePanelRef.bind(this);
-    }
     render() {
         const { isOpen, item: { name, image, title, subtitle, desc, buttonInfo, videoLink }, intl: { messages } } = this.props;
         const panelVerticalPadding = this.panelElem && this.panelElem.offsetHeight;
@@ -62,13 +56,13 @@ class AccordionItem extends Component {
         );
     }
 
-    handleButtonClick() {
+    handleButtonClick = () => {
         const { index } = this.props;
 
         this.props.onClick(index);
     }
 
-    handlePanelRef(element) {
+    handlePanelRef = (element) => {
         this.panelElem = element;
     }
 }

--- a/src/shared/components/what-can-you-build-section/accordion/accordion-item/index.module.css
+++ b/src/shared/components/what-can-you-build-section/accordion/accordion-item/index.module.css
@@ -5,7 +5,7 @@
     --vertical-padding-button: 20px;
     --vertical-padding-panel: 50px;
     --vertical-margin-content: 25px;
-    --video-ratio: 56.25%; /* ratio: 720 / 1280 = 0.5625 */
+    --line-height-h6: 35px;
 }
 
 .accordionButton {
@@ -109,12 +109,12 @@
 
             & h6 {
                 margin: var(--vertical-margin-content) 0;
-                line-height: 34.7px;
+                line-height: var(--line-height-h6);
             }
 
             & p {
                 margin-bottom: var(--vertical-margin-content);
-                line-height: 27.7px;
+                line-height: var(--line-height-medium);
             }
 
             & .videoWrapper {

--- a/src/shared/components/what-can-you-build-section/accordion/index.js
+++ b/src/shared/components/what-can-you-build-section/accordion/index.js
@@ -13,8 +13,6 @@ class Accordion extends Component {
         this.state = {
             openedItemIndex: -1,
         };
-
-        this.handleAccordionItemClick = this.handleAccordionItemClick.bind(this);
     }
 
     render() {
@@ -41,7 +39,7 @@ class Accordion extends Component {
         );
     }
 
-    handleAccordionItemClick(accordionItemIndex) {
+    handleAccordionItemClick = (accordionItemIndex) => {
         this.setState(({ openedItemIndex }) => ({
             openedItemIndex: accordionItemIndex === openedItemIndex ? -1 : accordionItemIndex,
         }));

--- a/src/shared/components/what-can-you-build-section/index.module.css
+++ b/src/shared/components/what-can-you-build-section/index.module.css
@@ -20,7 +20,7 @@
         & h1 {
             font-weight: var(--typography-text-weight-bold);
             text-align: center;
-            line-height: 48px;
+            line-height: var(--line-height-large);
         }
 
         & .sectionDescription {
@@ -31,7 +31,7 @@
                 width: 60%;
                 font-size: var(--typography-text-size);
                 font-weight: var(--typography-text-weight);
-                line-height: 27px;
+                line-height: var(--line-height-medium);
             }
         }
     }

--- a/src/shared/data/publications-and-talks/index.js
+++ b/src/shared/data/publications-and-talks/index.js
@@ -1,0 +1,21 @@
+const publicationsAndTalks = [
+    {
+        link: 'https://www.youtube.com/watch?v=2MpUj-Aua48',
+        description: 'publicationAndTalk1Desc',
+        active: true,
+    },
+    {
+        link: 'https://www.youtube.com/watch?v=HUVmypx9HGI',
+        description: 'publicationAndTalk2Desc',
+    },
+    {
+        link: 'https://www.youtube.com/watch?v=BA2rHlbB5i0',
+        description: 'publicationAndTalk3Desc',
+    },
+    {
+        link: 'https://www.youtube.com/watch?v=6kqgsGXpykM',
+        description: 'publicationAndTalk4Desc',
+    },
+];
+
+export default publicationsAndTalks;

--- a/src/shared/styles/imports/variables.css
+++ b/src/shared/styles/imports/variables.css
@@ -49,4 +49,9 @@
     --accordion-content-width: 79%;
     --transition-default-duration: 600ms;
     --transition-button-duration: 300ms;
+    --video-ratio: 56.25%;
+    --line-height-xsmall: 20px;
+    --line-height-small: 24px;
+    --line-height-medium: 27px;
+    --line-height-large: 48px;
 }


### PR DESCRIPTION
This PR implements "Publications & Talks" section. This section must have a set of videos of publications and/or talks and a small description.
For that reason, I've created a `js` file that exports an array of objects. Each object represents one publication/talk and it must have:

- link - `string` - URL to the corresponding video
- description - `string` - ID of `react-intl` translation that holds talk/publication short description
- active - `boolean`- just one of the objects must have this property as `true`. It indicates which video should be highlighted when the page loads.

Thus, if one wants to add a new publication/talk, one just need to: 

1. add a short description on each file of `react-intl` messages; 

2. add a new object to the `array` on [this](https://github.com/ipfs/js.ipfs.io/blob/feat/publications-and-talks-section/src/shared/data/publications-and-talks/index.js) file.