### PR TITLE
fix: fix languages design on desktop

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,8 +10,10 @@ const path = require('path');
 const fs = require('fs');
 const template = require('lodash/template');
 const wrap = require('lodash/wrap');
-const { availableLocales, defaultLocale } = require('./intl/config');
+const { defaultLocale } = require('./intl/config');
 const ServiceWorkerWebpackPlugin = require('serviceworker-webpack-plugin');
+const { getLocalesAcronym } = require('./src/utils/getLocalesUtils');
+const availableLocalesAcronym = getLocalesAcronym();
 
 module.exports.modifyWebpackConfig = ({ config, program }) => {
     // Allow requires from the src/ folder
@@ -109,7 +111,7 @@ exports.createLayouts = () => {
     // Create a layout for each locale, based on a template
     const layoutTemplate = fs.readFileSync(path.join(__dirname, 'src/layouts/index.js'));
 
-    availableLocales.forEach((locale) => {
+    availableLocalesAcronym.forEach((locale) => {
         const localeLayout = template(layoutTemplate)({ locale })
         .replace(/LayoutQuery/, `LayoutQuery_${locale}`);
 
@@ -123,7 +125,7 @@ exports.onCreatePage = ({ page, boundActionCreators }) => {
 
     deletePage(page);
 
-    availableLocales.forEach((locale) => {
+    availableLocalesAcronym.forEach((locale) => {
         createPage({
             ...page,
             layout: `index-${locale}`,

--- a/intl/config.js
+++ b/intl/config.js
@@ -1,7 +1,7 @@
 module.exports = {
     defaultLocale: 'en',
     availableLocales: [
-        'en',
-        'pt',
+        { acronym: 'en', fullForm: 'English' },
+        { acronym: 'pt', fullForm: 'Português (PT)' },
     ],
 };

--- a/src/shared/components/banner/index.module.css
+++ b/src/shared/components/banner/index.module.css
@@ -3,6 +3,7 @@
 
 .container {
     width: 100vw;
+    z-index: 3;
     padding: 25px;
     display: flex;
     justify-content: center;

--- a/src/shared/components/header/index.js
+++ b/src/shared/components/header/index.js
@@ -1,18 +1,63 @@
-import React from 'react';
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import { PropTypes } from 'prop-types';
 import classNames from 'classnames';
+import LocalesBar from 'shared/components/locales-bar';
 import DesktopNavbar from 'shared/components/navbar/desktop';
 import MobileNavbar from 'shared/components/navbar/mobile';
 // import Banner from 'shared/components/banner';
 import styles from './index.module.css';
 
-const Header = ({ className }) => (
-    <header className={ classNames(styles.header, className) }>
-        {/* <Banner /> */}
-        <DesktopNavbar />
-        <MobileNavbar />
-    </header>
-);
+class Header extends Component {
+    constructor() {
+        super();
+
+        this.state = {
+            scrolled: false,
+        };
+    }
+
+    componentDidMount() {
+        window.addEventListener('scroll', this.handleScroll);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('scroll', this.handleScroll);
+    }
+
+    render() {
+        const localesBarHeight = this.localesBarElem && this.localesBarElem.clientHeight;
+        const { className } = this.props;
+        const { scrolled } = this.state;
+
+        return (
+            <header className={ classNames(styles.header, className) }>
+                {/* <Banner /> */}
+                <LocalesBar scrolled={ scrolled } ref={ this.handleLocalesBarRef } />
+                <DesktopNavbar scrolled={ scrolled } localesBarHeight={ localesBarHeight } />
+                <MobileNavbar />
+            </header>
+        );
+    }
+
+    handleScroll = () => {
+        const scrollY = window.scrollY;
+
+        if (scrollY > 50 && !this.state.scrolled) {
+            this.setState({
+                scrolled: true,
+            });
+        } else if (scrollY <= 50 && this.state.scrolled) {
+            this.setState({
+                scrolled: false,
+            });
+        }
+    }
+
+    handleLocalesBarRef = (elementRef) => {
+        this.localesBarElem = ReactDOM.findDOMNode(elementRef);
+    }
+}
 
 Header.propTypes = {
     className: PropTypes.string,

--- a/src/shared/components/header/index.js
+++ b/src/shared/components/header/index.js
@@ -42,12 +42,13 @@ class Header extends Component {
 
     handleScroll = () => {
         const scrollY = window.scrollY;
+        const { scrolled } = this.state;
 
-        if (scrollY > 50 && !this.state.scrolled) {
+        if (scrollY > 50 && !scrolled) {
             this.setState({
                 scrolled: true,
             });
-        } else if (scrollY <= 50 && this.state.scrolled) {
+        } else if (scrollY <= 50 && scrolled) {
             this.setState({
                 scrolled: false,
             });

--- a/src/shared/components/locales-bar/index.js
+++ b/src/shared/components/locales-bar/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { injectIntl } from 'react-intl';
+import { PropTypes } from 'prop-types';
+import classNames from 'classnames';
+import { getLocalesFullForm, getIndexByAcronym } from 'utils/getLocalesUtils';
+
+import Link from 'shared/components/link';
+import styles from './index.module.css';
+
+const LocalesBar = ({ scrolled, intl: { locale } }) => {
+    const localesFullForm = getLocalesFullForm();
+    const currentLocaleIndex = getIndexByAcronym(locale);
+    const localesBarClassName = classNames(styles.localesBar, {
+        [styles.defaultLocalesBar]: !scrolled,
+        [styles.hideLocalesBar]: scrolled,
+    });
+    const renderLocales = localesFullForm.map((locale, index) => (
+        <Link key={ `localeF-${index}` } className={ index === currentLocaleIndex && styles.active } to="/" >{ locale }</Link>
+    ));
+
+    return (
+        <div className={ localesBarClassName }>
+            { renderLocales }
+        </div>
+    );
+};
+
+LocalesBar.propTypes = {
+    scrolled: PropTypes.bool.isRequired,
+    intl: PropTypes.object.isRequired,
+};
+
+export default injectIntl(LocalesBar);

--- a/src/shared/components/locales-bar/index.module.css
+++ b/src/shared/components/locales-bar/index.module.css
@@ -1,0 +1,44 @@
+@import "shared/styles/imports/variables.css";
+@import "shared/styles/imports/custom-medias.css";
+
+.localesBar {
+    z-index: 1;
+    padding: 20px 0 25px 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    background: var(--color-black-russian);
+    font-size: var(--typography-text-size-small);
+    transition: all var(--transition-button-duration) ease;
+
+    & a {
+        margin-top: 5px;
+        padding: 0 7px;
+        border-right: 1px solid var(--color-blue-dark-shade);
+        color: var(--color-blue-dark-shade);
+        text-decoration: none;
+        transition: var(--transition-default-duration) ease;
+
+        &:last-child {
+            border-right: unset;
+        }
+
+        &:hover {
+            color: var(--color-yellow);
+        }
+
+        &.active {
+            color: var(--color-white);
+        }
+    }
+}
+
+.hideLocalesBar {
+    transform: translateY(-100%);
+}
+
+@media (--layout-lte-small) {
+    .localesBar {
+        display: none;
+    }
+}

--- a/src/shared/components/locales-dropdown/index.js
+++ b/src/shared/components/locales-dropdown/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import localesConfig from '../../../../intl/config.js';
+import { getLocalesAcronym } from 'utils/getLocalesUtils';
 
 import Link from 'shared/components/link';
 import styles from './index.module.css';
@@ -15,7 +15,7 @@ class LocalesDropdown extends Component {
             isOpen: false,
         };
 
-        this.availableLocales = localesConfig.availableLocales;
+        this.availableLocales = getLocalesAcronym();
         this.currentLocale = props.intl.locale;
     }
 
@@ -28,9 +28,6 @@ class LocalesDropdown extends Component {
     }
 
     render() {
-        const dropdownClasses = classNames(styles.dropdown, {
-            [styles.desktopMargin]: !!this.props.desktopMargin,
-        });
         const dropButtonClasses = classNames(styles.dropButton, {
             [styles.openedDropdown]: this.state.isOpen,
         });
@@ -53,7 +50,7 @@ class LocalesDropdown extends Component {
         });
 
         return (
-            <div className={ dropdownClasses }>
+            <div className={ styles.dropdown }>
                 <button className={ dropButtonClasses } onClick={ this.handleToggleDropdown }>
                     { this.currentLocale.toUpperCase() }
                     <span className={ arrowClasses } />
@@ -84,7 +81,6 @@ class LocalesDropdown extends Component {
 
 LocalesDropdown.propTypes = {
     intl: PropTypes.object.isRequired,
-    desktopMargin: PropTypes.bool,
 };
 
 export default injectIntl(LocalesDropdown);

--- a/src/shared/components/locales-dropdown/index.module.css
+++ b/src/shared/components/locales-dropdown/index.module.css
@@ -1,9 +1,5 @@
 @import "shared/styles/imports/variables.css";
 
-.desktopMargin {
-    margin-left: calc(3% + 90px);
-}
-
 .dropdown {
     position: relative;
 
@@ -65,7 +61,11 @@
         z-index: 1;
         overflow: auto;
         display: none;
+
+        /* height: 0; */
         background-color: var(--color-menu-dark-blue);
+        box-shadow: 0 4px 2px -2px rgba(0, 0, 0, 0.76);
+        transition: height 1s ease;
 
         & a {
             width: 100%;
@@ -88,5 +88,7 @@
 
     & .show {
         display: block;
+
+        /* height: 100px; */
     }
 }

--- a/src/shared/components/navbar/desktop/index.js
+++ b/src/shared/components/navbar/desktop/index.js
@@ -1,74 +1,42 @@
-import React, { Component } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import Helmet from 'react-helmet';
 import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import Link from 'shared/components/link';
-import LocalesDropdown from 'shared/components/locales-dropdown';
 import styles from './index.module.css';
 
-class DesktopNavbar extends Component {
-    constructor(props) {
-        super(props);
+const DesktopNavbar = ({ scrolled, localesBarHeight, intl: { messages } }) => {
+    const navbarClasses = classNames(styles.container,
+        {
+            [styles.default]: !scrolled,
+            [styles.scrolled]: scrolled,
+        });
+    const currentTranslateYValue = scrolled ? localesBarHeight : 0;
 
-        this.state = {
-            scrolled: false,
-        };
-    }
-
-    componentDidMount() {
-        window.addEventListener('scroll', this.handleScroll);
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener('scroll', this.handleScroll);
-    }
-
-    render() {
-        const navbarClasses = classNames(styles.container,
-            {
-                [styles.default]: !this.state.scrolled,
-                [styles.scrolled]: this.state.scrolled,
-            });
-        const { messages } = this.props.intl;
-
-        return (
-            <div className={ navbarClasses }>
-                <div className={ styles.navbarMenu }>
-                    <Helmet>
-                        <script async defer src="https://buttons.github.io/buttons.js" />
-                    </Helmet>
-                    <Link to="/"> { messages.navMenuItem1.toUpperCase() } </Link>
-                    <Link to="/"> { messages.navMenuItem2.toUpperCase() } </Link>
-                    <Link to="/"> { messages.navMenuItem3.toUpperCase() } </Link>
-                    <Link to="/"> { messages.navMenuItem4.toUpperCase() } </Link>
-                    <a className="github-button" href="https://github.com/ntkme/github-buttons" data-show-count="true" aria-label="Star ntkme/github-buttons on GitHub">
+    return (
+        <div className={ navbarClasses } style={ { transform: `translateY(-${currentTranslateYValue}px)` } }>
+            <div className={ styles.navbarMenu }>
+                <Helmet>
+                    <script async defer src="https://buttons.github.io/buttons.js" />
+                </Helmet>
+                <Link to="/"> { messages.navMenuItem1.toUpperCase() } </Link>
+                <Link to="/"> { messages.navMenuItem2.toUpperCase() } </Link>
+                <Link to="/"> { messages.navMenuItem3.toUpperCase() } </Link>
+                <Link to="/"> { messages.navMenuItem4.toUpperCase() } </Link>
+                <a className="github-button" href="https://github.com/ntkme/github-buttons" data-show-count="true" aria-label="Star ntkme/github-buttons on GitHub">
                         Star
-                    </a>
-                    <LocalesDropdown desktopMargin />
-                </div>
+                </a>
             </div>
-        );
-    }
-
-    handleScroll = () => {
-        const scrollY = window.scrollY;
-
-        if (scrollY > 50 && !this.state.scrolled) {
-            this.setState({
-                scrolled: true,
-            });
-        } else if (scrollY <= 50 && this.state.scrolled) {
-            this.setState({
-                scrolled: false,
-            });
-        }
-    }
-}
+        </div>
+    );
+};
 
 DesktopNavbar.propTypes = {
+    scrolled: PropTypes.bool.isRequired,
     intl: PropTypes.object.isRequired,
+    localesBarHeight: PropTypes.number,
 };
 
 export default injectIntl(DesktopNavbar);

--- a/src/shared/components/navbar/desktop/index.module.css
+++ b/src/shared/components/navbar/desktop/index.module.css
@@ -9,7 +9,7 @@
     width: 100vw;
     font-size: var(--typography-menu-text-size);
     text-align: center;
-    transition: var(--transition-default-duration) ease;
+    transition: var(--transition-button-duration) ease;
 
     & .navbarMenu {
         position: relative;
@@ -37,7 +37,7 @@
 }
 
 .default {
-    padding: 60px 0 50px 0;
+    padding: 35px 0 35px 0;
 }
 
 .scrolled {

--- a/src/shared/components/navbar/desktop/index.module.css
+++ b/src/shared/components/navbar/desktop/index.module.css
@@ -37,11 +37,11 @@
 }
 
 .default {
-    padding: 35px 0 35px 0;
+    padding: 35px 0;
 }
 
 .scrolled {
-    padding: 25px 0 25px 0;
+    padding: 25px 0;
     background: var(--color-menu-dark-blue);
     box-shadow: 0 4px 2px -2px rgba(0, 0, 0, 0.76);
 }

--- a/src/shared/styles/imports/variables.css
+++ b/src/shared/styles/imports/variables.css
@@ -21,6 +21,8 @@
     --color-accordion-buttons: #17264d;
     --color-hex-svg-fill: #c6c9e2;
     --color-text-footer: #aab2b9;
+    --color-black-russian: rgba(9, 12, 18, 0.5);
+    --color-blue-dark-shade: #757b8f;
 }
 
 /* ==========================================================================

--- a/src/utils/getLocalesUtils.js
+++ b/src/utils/getLocalesUtils.js
@@ -1,0 +1,21 @@
+const localesConfig = require('../../intl/config.js');
+
+const locales = localesConfig.availableLocales;
+
+function getLocalesAcronym() {
+    return locales.map((locale) => locale.acronym);
+}
+
+function getLocalesFullForm() {
+    return locales.map((locale) => locale.fullForm);
+}
+
+function getIndexByAcronym(acronym) {
+    return locales.findIndex((locale) => locale.acronym === acronym);
+}
+
+module.exports = {
+    getLocalesAcronym,
+    getLocalesFullForm,
+    getIndexByAcronym,
+};


### PR DESCRIPTION
This PR updates desktop languages bar to the new design. 
Major changes:

- available locales array on `intl` config file has changed: it was an array of strings (locales acronyms) and it is an object now containing `acronym` and `fullForm`. 
E.g.: 
```javascript
availableLocales: [
        { acronym: 'en', fullForm: 'English' },
        { acronym: 'pt', fullForm: 'Português (PT)' }
    ]
```
- new `utils` file that exports 3 functions:

1. `getLocalesAcronym` - returns an array containing only the acronyms;
2. `getLocalesFullForm` - returns an array containing only the locales full form;
3. `getIndexByAcronym` - returns the index of a given acronym.