### PR TITLE
fix: add correct links to locales menu to change website locale

### DIFF
--- a/src/shared/components/button/index.module.css
+++ b/src/shared/components/button/index.module.css
@@ -2,6 +2,7 @@
 
 a.link {
     text-decoration: none;
+    text-align: center;
 
     & .customButton {
         min-width: 150px;

--- a/src/shared/components/carousel/carousel-projects-item/index.js
+++ b/src/shared/components/carousel/carousel-projects-item/index.js
@@ -13,7 +13,7 @@ const CarouselProjectsItem = ({ icon, desc, image, intl: { messages } }) => (
         <div className={ styles.desc }>{ messages[desc] }</div>
       </div>
       <div className={ styles.bottomContainer }>
-        <Button translationId="buttonLearnMore" path="test" />
+        <Button translationId="buttonLearnMore" path="/test" />
       </div>
     </div>
     <div className={ styles.rightContainer }><img src={ image } /></div>

--- a/src/shared/components/community-section/index.js
+++ b/src/shared/components/community-section/index.js
@@ -20,9 +20,9 @@ const Community = () => (
       <div className={ styles.socialLinksContainer }>
         <FormattedMessage tagName="p" id="communitySocialTitle" />
         <div className={ styles.socialLinks }>
-          <Button translationId="buttonIrcFreenode" path="test" />
-          <Button translationId="buttonGithub" path="test" modifier="github" />
-          <Button translationId="buttonTwitter" path="test" modifier="twitter" />
+          <Button translationId="buttonIrcFreenode" path="/test" />
+          <Button translationId="buttonGithub" path="/test" modifier="github" />
+          <Button translationId="buttonTwitter" path="/test" modifier="twitter" />
         </div>
       </div>
     </div>

--- a/src/shared/components/getting-started-section/index.js
+++ b/src/shared/components/getting-started-section/index.js
@@ -21,7 +21,7 @@ const GettingStarted = () =>
         <div className={ styles.panel } >
           <StepsList />
         </div>
-        <Button translationId="buttonLearnMore" path="test" />
+        <Button translationId="buttonLearnMore" path="/test" />
       </div>
     </div>
   )

--- a/src/shared/components/hero-section/index.js
+++ b/src/shared/components/hero-section/index.js
@@ -60,7 +60,7 @@ class Hero extends Component {
             { isDataLoaded && !existsError ? this.renderPkgInfo(info, isDataLoaded) : this.renderErrorMessage(errorMessage) }
           </div>
           <div className={ styles.buttonContent }>
-            <Button translationId="buttonLearnMore" path="test" />
+            <Button translationId="buttonLearnMore" path="/test" />
           </div>
         </div>
       </div>

--- a/src/shared/components/link/index.js
+++ b/src/shared/components/link/index.js
@@ -4,12 +4,12 @@ import GatsbyLink from 'gatsby-link'
 
 class Link extends Component {
   render () {
-    const { to, ...rest } = this.props
+    const { to, changeLocale, ...rest } = this.props
     const { intl } = this.context
 
     const localelizedTo = intl.defaultLocale !== intl.locale ? `/${intl.locale}${to}` : to
 
-    return <GatsbyLink { ...rest } to={ localelizedTo } />
+    return <GatsbyLink { ...rest } to={ changeLocale ? to : localelizedTo } />
   }
 
     static propTypes = {

--- a/src/shared/components/locales-bar/index.js
+++ b/src/shared/components/locales-bar/index.js
@@ -2,21 +2,30 @@ import React from 'react'
 import { injectIntl } from 'react-intl'
 import { PropTypes } from 'prop-types'
 import classNames from 'classnames'
-import { getLocalesFullForm, getIndexByAcronym } from 'utils/getLocalesUtils'
+import { getDefaultLocale, getLocales, getIndexByAcronym } from 'utils/getLocalesUtils'
 
 import Link from 'shared/components/link'
 import styles from './index.module.css'
 
 const LocalesBar = ({ scrolled, intl: { locale } }) => {
-  const localesFullForm = getLocalesFullForm()
+  const locales = getLocales()
   const currentLocaleIndex = getIndexByAcronym(locale)
   const localesBarClassName = classNames(styles.localesBar, {
     [styles.defaultLocalesBar]: !scrolled,
     [styles.hideLocalesBar]: scrolled
   })
-  const renderLocales = localesFullForm.map((locale, index) => (
-    <Link key={ `localeF-${index}` } className={ index === currentLocaleIndex && styles.active } to="/" >{ locale }</Link>
-  ))
+  const defaultLocale = getDefaultLocale()
+  const renderLocales = locales.map((locale, index) => {
+    const to = defaultLocale === locale.acronym ? '/' : `/${locale.acronym}`
+    return (
+      <Link key={ `localeF-${index}` }
+        changeLocale
+        className={ index === currentLocaleIndex && styles.active }
+        to={ to } >
+        { locale.fullForm }
+      </Link>
+    )
+  })
 
   return (
     <div className={ localesBarClassName }>

--- a/src/shared/components/locales-dropdown/index.js
+++ b/src/shared/components/locales-dropdown/index.js
@@ -46,7 +46,15 @@ class LocalesDropdown extends Component {
         return null
       }
 
-      return <Link key={ index } to="/">{ locale.toUpperCase() }</Link>
+      const to = `/${locale}`
+
+      return (
+        <Link key={ index }
+          changeLocale
+          to={ to }>
+          { locale.toUpperCase() }
+        </Link>
+      )
     })
 
     return (

--- a/src/utils/getLocalesUtils.js
+++ b/src/utils/getLocalesUtils.js
@@ -2,6 +2,14 @@ const localesConfig = require('../../intl/config.js')
 
 const locales = localesConfig.availableLocales
 
+function getDefaultLocale () {
+  return localesConfig.defaultLocale
+}
+
+function getLocales () {
+  return locales
+}
+
 function getLocalesAcronym () {
   return locales.map((locale) => locale.acronym)
 }
@@ -15,6 +23,8 @@ function getIndexByAcronym (acronym) {
 }
 
 module.exports = {
+  getDefaultLocale,
+  getLocales,
   getLocalesAcronym,
   getLocalesFullForm,
   getIndexByAcronym


### PR DESCRIPTION
This PR fixes both `locales-bar` and `locales-dropdown` menus to change website locale when a user clicks on the locale. 
I've added a new boolean prop (`changeLocale`) to [`Link`](https://github.com/ipfs/js.ipfs.io/blob/master/src/shared/components/link/index.js) component which indicates that locale should be changed instead of linking to other page/section.