### PR TITLE
fix: update projects array

### DIFF
--- a/src/shared/components/button/index.js
+++ b/src/shared/components/button/index.js
@@ -6,13 +6,17 @@ import Link from 'shared/components/link'
 
 import styles from './index.module.css'
 
-const Button = ({ translationId, path, className, intl: { messages }, modifier }) => (
-  <Link to={ path } className={ styles.link } >
-    <div className={ classNames(styles.customButton, className, styles[modifier]) }>
-      { messages.buttons[translationId] }
-    </div>
-  </Link>
-)
+const Button = ({ translationId, path, href, className, intl: { messages }, modifier }) => {
+  const urlProp = path ? { to: path } : { href }
+
+  return (
+    <Link { ...urlProp } className={ styles.link } >
+      <div className={ classNames(styles.customButton, className, styles[modifier]) }>
+        { messages.buttons[translationId] }
+      </div>
+    </Link>
+  )
+}
 
 Button.defaultProps = {
   modifier: 'default'
@@ -21,7 +25,8 @@ Button.defaultProps = {
 Button.propTypes = {
   intl: PropTypes.object.isRequired,
   translationId: PropTypes.string.isRequired,
-  path: PropTypes.string.isRequired,
+  path: PropTypes.string,
+  href: PropTypes.string,
   className: PropTypes.string,
   modifier: PropTypes.oneOf(['default', 'github', 'twitter'])
 }

--- a/src/shared/components/carousel/carousel-projects-item/index.js
+++ b/src/shared/components/carousel/carousel-projects-item/index.js
@@ -4,7 +4,7 @@ import { PropTypes } from 'prop-types'
 import Button from 'shared/components/button'
 import styles from './index.module.css'
 
-const CarouselProjectsItem = ({ icon, desc, image }) => (
+const CarouselProjectsItem = ({ icon, desc, link, image }) => (
   <div className={ styles.container }>
     <div className={ styles.leftContainer }>
       <div className={ styles.topContainer }>
@@ -12,7 +12,7 @@ const CarouselProjectsItem = ({ icon, desc, image }) => (
         <div className={ styles.desc }>{ desc }</div>
       </div>
       <div className={ styles.bottomContainer }>
-        <Button translationId="buttonLearnMore" path="/test" />
+        <Button translationId="buttonLearnMore" href={ link } />
       </div>
     </div>
     <div className={ styles.rightContainer }><img src={ image } /></div>
@@ -22,6 +22,7 @@ const CarouselProjectsItem = ({ icon, desc, image }) => (
 CarouselProjectsItem.propTypes = {
   icon: PropTypes.element.isRequired,
   desc: PropTypes.string.isRequired,
+  link: PropTypes.string.isRequired,
   image: PropTypes.string.isRequired
 }
 

--- a/src/shared/components/carousel/index.js
+++ b/src/shared/components/carousel/index.js
@@ -55,6 +55,7 @@ class Carousel extends Component {
           <CarouselProjectsItem key={ `carousel-item-${index}` }
             icon={ item.icon }
             desc={ translationsList[translationIndex].desc }
+            link={ item.link }
             image={ item.image } />
         )
       })

--- a/src/shared/components/link/index.js
+++ b/src/shared/components/link/index.js
@@ -4,16 +4,24 @@ import GatsbyLink from 'gatsby-link'
 
 class Link extends Component {
   render () {
-    const { to, changeLocale, ...rest } = this.props
+    const { to, changeLocale, href, ...rest } = this.props
     const { intl } = this.context
 
-    const localelizedTo = intl.defaultLocale !== intl.locale ? `/${intl.locale}${to}` : to
+    if (to) {
+      const localelizedTo = intl.defaultLocale !== intl.locale ? `/${intl.locale}${to}` : to
 
-    return <GatsbyLink { ...rest } to={ changeLocale ? to : localelizedTo } />
+      return <GatsbyLink { ...rest } to={ changeLocale ? to : localelizedTo } />
+    }
+
+    return (
+      <a { ...rest } href={ href } target="_blank" rel="noopener noreferrer" />
+    )
   }
 
     static propTypes = {
-      to: PropTypes.string.isRequired
+      to: PropTypes.string,
+      href: PropTypes.string,
+      changeLocale: PropTypes.bool
     }
 
     static contextTypes = {

--- a/src/shared/data/what-are-people-building/index.js
+++ b/src/shared/data/what-are-people-building/index.js
@@ -7,12 +7,14 @@ const projects = [
   {
     translationListIndex: 0,
     icon: <ParatiiSvg />,
-    image: ParatiiPrintScreen
+    image: ParatiiPrintScreen,
+    link: 'https://paratii.video/'
   },
   {
     translationListIndex: 1,
     icon: <ParatiiSvg />,
-    image: ParatiiPrintScreen
+    image: ParatiiPrintScreen,
+    link: 'https://paratii.video/'
   }
 ]
 


### PR DESCRIPTION
This PR changes [`what-are-people-building` array](https://github.com/ipfs/js.ipfs.io/blob/fix/what-are-people-building-projects-array/src/shared/data/what-are-people-building/index.js) in order to allow `link` key that works as an external link for the `learn more` button.

I've also changed [`link`](https://github.com/ipfs/js.ipfs.io/blob/fix/what-are-people-building-projects-array/src/shared/components/link/index.js) component to return an `anchor` tag when we want to use external links.
When we use `to` prop on `link` component we want to do an internal navigation. When we use `href` prop, we want to do an external navigation which returns an `anchor` tag.