### PR TITLE
fix: fix libp2p-switch using the wrong big.js

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -24,6 +24,15 @@ module.exports.modifyWebpackConfig = ({ config, program }) => {
     target: 'web'
   })
 
+  // Fix Gatsby setting `resolve.modulesDirectories` to `path.resolve(__dirname, "node_modules")`
+  // which causes module resolution errors when the npm tree is deduped
+  // See https://github.com/webpack/webpack/issues/6538#issuecomment-367324775
+  config.merge((current) => {
+    current.resolve.modulesDirectories = ['node_modules']
+
+    return current
+  })
+
   // Add prefix to all svg class or id selectors to avoid styles override
   // config.merge((current) => {
   //     config.loader('svg-react-loader', (current) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3476,6 +3476,14 @@
       "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A==",
       "dev": true
     },
+    "@nodeutils/defaults-deep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
+      "integrity": "sha1-uxEk3I184LxdodZorOWBSSWO8gs=",
+      "requires": {
+        "lodash": "^4.15.0"
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -3846,6 +3854,19 @@
         "long": "^3.2.0"
       }
     },
+    "File": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/File/-/File-0.10.2.tgz",
+      "integrity": "sha1-6Jn3dtJz4iQ7qGEFuzsFbQ+5VgQ=",
+      "requires": {
+        "mime": ">= 0.0.0"
+      }
+    },
+    "FileList": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/FileList/-/FileList-0.10.2.tgz",
+      "integrity": "sha1-YAOxqXFZNBZLZ8Q0rWqHQaHNFHo="
+    },
     "JSONStream": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
@@ -3857,18 +3878,11 @@
       }
     },
     "abstract-leveldown": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-      "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
       "requires": {
-        "xtend": "~3.0.0"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-        }
+        "xtend": "~4.0.0"
       }
     },
     "accept": {
@@ -7028,11 +7042,6 @@
       "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
       "dev": true
     },
-    "buffer-equals": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
-      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
-    },
     "buffer-fill": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
@@ -7083,6 +7092,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "bufferjs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-3.0.1.tgz",
+      "integrity": "sha1-BpLoKcsQoQVQ5kc5CwNesGw46O8="
     },
     "buildmail": {
       "version": "4.0.1",
@@ -7561,6 +7575,11 @@
       "requires": {
         "webpack-core": "^0.4.8"
       }
+    },
+    "chunky": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/chunky/-/chunky-0.0.0.tgz",
+      "integrity": "sha1-HnWAojwIOJfSrWYkWefv2EZfYIo="
     },
     "ci-info": {
       "version": "1.1.3",
@@ -9268,54 +9287,32 @@
       }
     },
     "datastore-fs": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.4.2.tgz",
-      "integrity": "sha512-mJ511KiZP1zrkEnCvMqvrurW6YSf3QT4P3bdGVftPl+DeaGxC/gdwj8DE9cWsmyD6E1a50jU2Q8IqhaZGNEBbg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.5.0.tgz",
+      "integrity": "sha512-l2WF+/TFzzCY3L0b4GYYa196X25PqR2jZnLvqXtz2WODkTXZTcZJ+s4+KAnUAc6TMxWejN8NkEnkcPL05lKSSA==",
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
         "datastore-core": "~0.4.0",
         "glob": "^7.1.2",
         "graceful-fs": "^4.1.11",
         "interface-datastore": "^0.4.2",
-        "mkdirp": "^0.5.1",
-        "pull-stream": "^3.6.1",
+        "mkdirp": "~0.5.1",
+        "pull-stream": "^3.6.8",
         "write-file-atomic": "^2.3.0"
       }
     },
     "datastore-level": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.7.0.tgz",
-      "integrity": "sha512-Wgm6kzkXadFOVkzRpu7KfSm6QwxjsgfPRCrcvVQuR4/CsWeREnmyuzu580fLywRmlIQMbcncu6W02W0HyAzjng==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.8.0.tgz",
+      "integrity": "sha512-RSklSUhf4CBNXm8akR+Q7LvDE4J6NA8XfZ3h5pGPempdXcExFui5CoyHJscOlu0culvZzuJLU4k5PxcLPGzuMw==",
       "requires": {
         "datastore-core": "~0.4.0",
+        "encoding-down": "^5.0.2",
         "interface-datastore": "~0.4.1",
-        "level-js": "^2.2.4",
-        "leveldown": "^1.9.0",
-        "levelup": "^1.3.9",
+        "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
+        "leveldown": "^3.0.2",
+        "levelup": "^2.0.2",
         "pull-stream": "^3.6.1"
-      },
-      "dependencies": {
-        "level-js": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz",
-          "integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
-          "requires": {
-            "abstract-leveldown": "~0.12.0",
-            "idb-wrapper": "^1.5.0",
-            "isbuffer": "~0.0.0",
-            "ltgt": "^2.1.2",
-            "typedarray-to-buffer": "~1.0.0",
-            "xtend": "~2.1.2"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
       }
     },
     "date-fns": {
@@ -9420,17 +9417,17 @@
       "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
     },
     "deferred-leveldown": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
+      "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
       "requires": {
-        "abstract-leveldown": "~2.6.0"
+        "abstract-leveldown": "~4.0.0"
       },
       "dependencies": {
         "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "requires": {
             "xtend": "~4.0.0"
           }
@@ -9760,12 +9757,12 @@
       }
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
+      "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "doctrine": {
@@ -10726,6 +10723,18 @@
         "iconv-lite": "~0.4.13"
       }
     },
+    "encoding-down": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
+      "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
+      "requires": {
+        "abstract-leveldown": "^5.0.0",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -10867,6 +10876,16 @@
       "integrity": "sha1-j0dAiy1oCxIm/9IF1QH499XikgY=",
       "requires": {
         "prom-client": "^10.0.0"
+      },
+      "dependencies": {
+        "prom-client": {
+          "version": "10.2.3",
+          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
+          "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
+          "requires": {
+            "tdigest": "^0.1.1"
+          }
+        }
       }
     },
     "err-code": {
@@ -11448,15 +11467,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "eth-hash-to-cid": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eth-hash-to-cid/-/eth-hash-to-cid-0.1.1.tgz",
-      "integrity": "sha512-qRmanZnp+YqLGpZaaBX49jEBVpUhYvosNBA/6lrgDDdVhzGCeMbpFycJYyR3prgrxMRPDoMk1H7iMeKRVZKLPA==",
-      "requires": {
-        "cids": "^0.5.3",
-        "multihashes": "^0.4.13"
-      }
     },
     "ethereum-common": {
       "version": "0.2.0",
@@ -12146,6 +12156,21 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
+    "file-api": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/file-api/-/file-api-0.10.4.tgz",
+      "integrity": "sha1-LxASJttyfMAXKg3WiPL2iD1SiD0=",
+      "requires": {
+        "File": ">= 0.10.0",
+        "FileList": ">= 0.10.0",
+        "bufferjs": "> 0.2.0",
+        "file-error": ">= 0.10.0",
+        "filereader": ">= 0.10.3",
+        "formdata": ">= 0.10.0",
+        "mime": ">= 1.2.11",
+        "remedial": ">= 1.0.7"
+      }
+    },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
@@ -12155,6 +12180,11 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
+    },
+    "file-error": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/file-error/-/file-error-0.10.2.tgz",
+      "integrity": "sha1-ljtIuSc7PUuEtADuVxvHixc5cko="
     },
     "file-loader": {
       "version": "0.9.0",
@@ -12206,6 +12236,20 @@
       "requires": {
         "filenamify": "^1.0.0",
         "humanize-url": "^1.0.0"
+      }
+    },
+    "filereader": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/filereader/-/filereader-0.10.3.tgz",
+      "integrity": "sha1-x0fUos2PYeVBinwH/hJXpD8KzbE="
+    },
+    "filereader-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filereader-stream/-/filereader-stream-2.0.0.tgz",
+      "integrity": "sha1-sw1aW/bRTGONfrVeGTq7mG+ASKE=",
+      "requires": {
+        "from2": "^2.1.0",
+        "typedarray-to-buffer": "^3.0.4"
       }
     },
     "filesize": {
@@ -12779,6 +12823,11 @@
         "readable-stream": "^2.0.4"
       }
     },
+    "fnv1a": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.0.1.tgz",
+      "integrity": "sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU="
+    },
     "follow-redirects": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
@@ -12816,6 +12865,11 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
+    "foreachasync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -12829,6 +12883,26 @@
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/formdata/-/formdata-0.10.4.tgz",
+      "integrity": "sha1-liH9wMw2H0oBEd5dJbNfanjcVaA=",
+      "requires": {
+        "File": "^0.10.2",
+        "FileList": "^0.10.2",
+        "bufferjs": "^2.0.0",
+        "filereader": "^0.10.3",
+        "foreachasync": "^3.0.0",
+        "remedial": "^1.0.7"
+      },
+      "dependencies": {
+        "bufferjs": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-2.0.0.tgz",
+          "integrity": "sha1-aF5x7VwGAOPXA/+b0BK7MnCjnig="
+        }
       }
     },
     "forwarded": {
@@ -12863,7 +12937,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -12917,6 +12990,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
+    },
+    "fs-ext": {
+      "version": "github:baudehlo/node-fs-ext#7c9824f3dc330e795aa13359d96252860bd3a684",
+      "from": "github:baudehlo/node-fs-ext#master",
+      "optional": true,
+      "requires": {
+        "nan": "^2.10.0"
+      }
     },
     "fs-extra": {
       "version": "4.0.3",
@@ -14243,19 +14324,12 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-folder-size": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-1.0.1.tgz",
-      "integrity": "sha1-gC+kIIQ03nEgUYKxWrfxNSCI5YA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.0.tgz",
+      "integrity": "sha512-5h4efQY/sHvf9ZuwOan1HgNaRyApKnJjZ1ZdTOPkpTjIHZNqeMTabBU/LLN6lU9jncBwxJKFcG9cuqiGhu47uQ==",
       "requires": {
-        "async": "^1.4.2",
-        "gar": "^1.0.2"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        }
+        "gar": "^1.0.2",
+        "tiny-each-async": "2.0.3"
       }
     },
     "get-func-name": {
@@ -14811,8 +14885,7 @@
     "git-validate": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/git-validate/-/git-validate-2.2.2.tgz",
-      "integrity": "sha1-nMj/ABF3lXoRcmq1CNQVu4Cxi88=",
-      "dev": true
+      "integrity": "sha1-nMj/ABF3lXoRcmq1CNQVu4Cxi88="
     },
     "gitconfiglocal": {
       "version": "1.0.0",
@@ -15858,10 +15931,13 @@
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
     },
-    "idb-wrapper": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
-      "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg=="
+    "idb-readable-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/idb-readable-stream/-/idb-readable-stream-0.0.4.tgz",
+      "integrity": "sha1-MoPaZkW/ayINxhumHfYr7l2uSs8=",
+      "requires": {
+        "xtend": "^4.0.1"
+      }
     },
     "ieee754": {
       "version": "1.1.11",
@@ -16208,99 +16284,124 @@
       "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
     "ipfs": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.28.2.tgz",
-      "integrity": "sha512-ryNxKhNQvU33M3tvRwk/pVG63ZLiS1R5a2zbrqAS75DSrO3N/sRd/iCr8THr4EPIdnYfGEEWluqig6n6rBzl4A==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.30.1.tgz",
+      "integrity": "sha512-Vks8ADqtuRR9lMDr7hS7qpA2C6TiJDwwsK7m9Bih0nvy+ZWlnvDWajJD9h+zUtkIJZT2PldcT5/6rZhQKd5TcQ==",
       "requires": {
-        "async": "^2.6.0",
-        "big.js": "^5.0.3",
+        "@nodeutils/defaults-deep": "^1.1.0",
+        "async": "^2.6.1",
+        "big.js": "^5.1.2",
         "binary-querystring": "~0.1.2",
-        "bl": "^1.2.1",
-        "boom": "^7.1.1",
+        "bl": "^2.0.1",
+        "boom": "^7.2.0",
         "bs58": "^4.0.1",
         "byteman": "^1.3.5",
-        "cids": "~0.5.2",
+        "cids": "~0.5.3",
         "debug": "^3.1.0",
-        "file-type": "^7.6.0",
-        "filesize": "^3.6.0",
+        "file-type": "^8.0.0",
+        "filesize": "^3.6.1",
+        "fnv1a": "^1.0.1",
         "fsm-event": "^2.1.0",
-        "get-folder-size": "^1.0.1",
+        "get-folder-size": "^2.0.0",
         "glob": "^7.1.2",
         "hapi": "^16.6.2",
         "hapi-set-header": "^1.0.2",
         "hoek": "^5.0.3",
         "human-to-milliseconds": "^1.0.0",
-        "ipfs-api": "^18.1.2",
-        "ipfs-bitswap": "~0.19.0",
-        "ipfs-block": "~0.6.1",
-        "ipfs-block-service": "~0.13.0",
+        "interface-datastore": "~0.4.2",
+        "ipfs-api": "^22.2.1",
+        "ipfs-bitswap": "~0.20.2",
+        "ipfs-block": "~0.7.1",
+        "ipfs-block-service": "~0.14.0",
+        "ipfs-http-response": "~0.1.2",
+        "ipfs-mfs": "~0.1.0",
         "ipfs-multipart": "~0.1.0",
-        "ipfs-repo": "~0.18.7",
-        "ipfs-unixfs": "~0.1.14",
-        "ipfs-unixfs-engine": "~0.24.4",
-        "ipld": "^0.15.0",
-        "is-ipfs": "^0.3.2",
+        "ipfs-repo": "~0.22.1",
+        "ipfs-unixfs": "~0.1.15",
+        "ipfs-unixfs-engine": "~0.30.0",
+        "ipld": "~0.17.2",
+        "ipld-dag-cbor": "~0.12.1",
+        "ipld-dag-pb": "~0.14.5",
+        "is-ipfs": "~0.3.2",
+        "is-pull-stream": "~0.0.0",
         "is-stream": "^1.1.0",
-        "joi": "^13.1.2",
-        "joi-browser": "^13.0.1",
-        "joi-multiaddr": "^1.0.1",
-        "libp2p": "~0.18.0",
-        "libp2p-circuit": "~0.1.4",
-        "libp2p-floodsub": "~0.14.1",
-        "libp2p-kad-dht": "~0.8.0",
+        "joi": "^13.4.0",
+        "joi-browser": "^13.4.0",
+        "joi-multiaddr": "^2.0.0",
+        "libp2p": "~0.22.0",
+        "libp2p-bootstrap": "~0.9.3",
+        "libp2p-circuit": "~0.2.0",
+        "libp2p-floodsub": "~0.15.0",
+        "libp2p-kad-dht": "~0.10.0",
         "libp2p-keychain": "~0.3.1",
-        "libp2p-mdns": "~0.9.2",
-        "libp2p-multiplex": "~0.5.1",
-        "libp2p-railing": "~0.7.1",
-        "libp2p-secio": "~0.9.3",
-        "libp2p-tcp": "~0.11.6",
-        "libp2p-webrtc-star": "~0.13.4",
-        "libp2p-websocket-star": "~0.7.7",
-        "libp2p-websockets": "~0.10.5",
-        "lodash.flatmap": "^4.5.0",
-        "lodash.get": "^4.4.2",
-        "lodash.sortby": "^4.7.0",
-        "lodash.values": "^4.3.0",
-        "mafmt": "^4.0.0",
+        "libp2p-mdns": "~0.12.0",
+        "libp2p-mplex": "~0.8.0",
+        "libp2p-secio": "~0.10.0",
+        "libp2p-tcp": "~0.12.0",
+        "libp2p-webrtc-star": "~0.15.3",
+        "libp2p-websocket-star": "~0.8.1",
+        "libp2p-websockets": "~0.12.0",
+        "lodash": "^4.17.10",
+        "mafmt": "^6.0.0",
         "mime-types": "^2.1.18",
         "mkdirp": "~0.5.1",
-        "multiaddr": "^3.0.2",
+        "multiaddr": "^5.0.0",
+        "multibase": "~0.4.0",
         "multihashes": "~0.4.13",
         "once": "^1.4.0",
         "path-exists": "^3.0.0",
-        "peer-book": "~0.5.4",
-        "peer-id": "~0.10.6",
-        "peer-info": "~0.11.6",
+        "peer-book": "~0.8.0",
+        "peer-id": "~0.11.0",
+        "peer-info": "~0.14.1",
         "progress": "^2.0.0",
-        "prom-client": "^10.2.2",
-        "prometheus-gc-stats": "^0.5.0",
+        "prom-client": "^11.1.1",
+        "prometheus-gc-stats": "~0.5.1",
         "promisify-es6": "^1.0.3",
         "pull-abortable": "^4.1.1",
-        "pull-defer": "^0.2.2",
+        "pull-defer": "~0.2.2",
         "pull-file": "^1.1.0",
-        "pull-ndjson": "^0.1.1",
+        "pull-ndjson": "~0.1.1",
         "pull-paramap": "^1.2.2",
         "pull-pushable": "^2.2.0",
         "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.2",
+        "pull-stream": "^3.6.8",
         "pull-stream-to-stream": "^1.3.4",
         "pull-zip": "^2.0.1",
-        "read-pkg-up": "^3.0.0",
-        "readable-stream": "2.3.4",
-        "safe-buffer": "^5.1.1",
+        "read-pkg-up": "^4.0.0",
+        "readable-stream": "2.3.6",
         "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^1.5.5",
+        "tar-stream": "^1.6.1",
         "temp": "~0.8.3",
         "through2": "^2.0.3",
-        "update-notifier": "^2.3.0",
-        "yargs": "^11.0.0",
-        "yargs-parser": "^9.0.2"
+        "update-notifier": "^2.5.0",
+        "yargs": "^12.0.1",
+        "yargs-parser": "^10.1.0",
+        "yargs-promise": "^1.1.0"
       },
       "dependencies": {
+        "asn1.js": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+          "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
         "big.js": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.1.2.tgz",
           "integrity": "sha512-qG6ZOc1lY84Bn8p/z9xvJisj9F4PRyo0pOGqGNYc7gS3p1WciS/3XcLuNI3Z/yYZpMNFhHeX3YNENwgrQq0NTA=="
+        },
+        "bl": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.0.1.tgz",
+          "integrity": "sha512-FrMgLukB9jujvJ92p5TA0hcKIHtInVXXhxD7qgAuV7k0cbPt9USZmOYnhDXH6IsnGeIUglX42TSBV7Gn4q5sbQ==",
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
         },
         "debug": {
           "version": "3.1.0",
@@ -16310,10 +16411,13 @@
             "ms": "2.0.0"
           }
         },
-        "file-type": {
-          "version": "7.7.1",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
-          "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ=="
+        "decamelize": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+          "requires": {
+            "xregexp": "4.0.0"
+          }
         },
         "filesize": {
           "version": "3.6.1",
@@ -16321,11 +16425,11 @@
           "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
         },
         "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "hoek": {
@@ -16333,12 +16437,23 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
           "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
         },
-        "ipfs-block": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
-          "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
+        "ipld-dag-pb": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.14.5.tgz",
+          "integrity": "sha512-HHKqyjP1m9PxbT1+EWrbq/dH6uIY90mvwQ6G79JWKsdCsyOvRbyCdmZmXbbuTN9JBFcoMG2684qix+HtiEz0fQ==",
           "requires": {
-            "cids": "^0.5.2"
+            "async": "^2.6.1",
+            "bs58": "^4.0.1",
+            "buffer-loader": "~0.0.1",
+            "cids": "~0.5.3",
+            "class-is": "^1.1.0",
+            "is-ipfs": "~0.3.2",
+            "multihashes": "~0.4.13",
+            "multihashing-async": "~0.5.1",
+            "protons": "^1.0.1",
+            "pull-stream": "^3.6.8",
+            "pull-traverse": "^1.0.3",
+            "stable": "~0.1.8"
           }
         },
         "joi": {
@@ -16349,6 +16464,41 @@
             "hoek": "5.x.x",
             "isemail": "3.x.x",
             "topo": "3.x.x"
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
+          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.2.0",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.8",
+            "node-forge": "^0.7.5",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "multihashing-async": {
+              "version": "0.4.8",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+              "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+              "requires": {
+                "async": "^2.6.0",
+                "blakejs": "^1.1.0",
+                "js-sha3": "^0.7.0",
+                "multihashes": "~0.4.13",
+                "murmurhash3js": "^3.0.1",
+                "nodeify": "^1.0.1"
+              }
+            }
           }
         },
         "load-json-file": {
@@ -16362,26 +16512,63 @@
             "strip-bom": "^3.0.0"
           }
         },
-        "mafmt": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-4.0.0.tgz",
-          "integrity": "sha512-zTqHhC9UUYlOkTwOXkdNqCE5U7vuz5UzlRJa4Et3ddCu/Sq36Z8F9mWCGdoqzahDcnRiGc515XjsnkAQHdH55g==",
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "requires": {
-            "multiaddr": "^3.0.2"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
+          "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
           "requires": {
             "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
             "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
             "lodash.filter": "^4.6.0",
             "lodash.map": "^4.6.0",
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
+        },
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
+          "requires": {
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
         },
         "parse-json": {
           "version": "4.0.0",
@@ -16400,14 +16587,15 @@
             "pify": "^3.0.0"
           }
         },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
+        "peer-id": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
+          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
           "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
+            "async": "^2.6.1",
+            "libp2p-crypto": "~0.13.0",
+            "lodash": "^4.17.10",
+            "multihashes": "~0.4.13"
           }
         },
         "read-pkg": {
@@ -16421,35 +16609,18 @@
           }
         },
         "read-pkg-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "requires": {
-            "find-up": "^2.0.0",
+            "find-up": "^3.0.0",
             "read-pkg": "^3.0.0"
           }
         },
-        "readable-stream": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
-          "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
+        "stable": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+          "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
         },
         "topo": {
           "version": "3.0.0",
@@ -16458,99 +16629,207 @@
           "requires": {
             "hoek": "5.x.x"
           }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#master"
+        },
+        "xregexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+          "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
+        },
+        "yargs": {
+          "version": "12.0.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
+          "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^2.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^10.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
         }
       }
     },
     "ipfs-api": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-18.2.1.tgz",
-      "integrity": "sha512-ffT6tO4KkACztnA3wm2R1hanQLjyeYgTaaXLtoetMvdKTuI6JeOuwg7lv7HfLpIBRKfeYU98e2wzH7Vv7bhERw==",
+      "version": "22.2.4",
+      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-22.2.4.tgz",
+      "integrity": "sha512-9RReGD3/O8XQ+K83o9eqge3ULqQGDO9ijg+x3RKskb431Ftqp8Z4MiPRiQxpXKtTkDa1jhStXj2sfENpCQRu9w==",
       "requires": {
-        "async": "^2.6.0",
-        "big.js": "^5.0.3",
+        "async": "^2.6.1",
+        "big.js": "^5.1.2",
         "bs58": "^4.0.1",
         "cids": "~0.5.3",
         "concat-stream": "^1.6.2",
+        "debug": "^3.1.0",
         "detect-node": "^2.0.3",
         "flatmap": "0.0.3",
         "glob": "^7.1.2",
-        "ipfs-block": "~0.6.1",
-        "ipfs-unixfs": "~0.1.14",
-        "ipld-dag-pb": "~0.13.1",
-        "is-ipfs": "^0.3.2",
+        "ipfs-block": "~0.7.1",
+        "ipfs-unixfs": "~0.1.15",
+        "ipld-dag-cbor": "~0.12.1",
+        "ipld-dag-pb": "~0.14.5",
+        "is-ipfs": "~0.3.2",
+        "is-pull-stream": "0.0.0",
         "is-stream": "^1.1.0",
-        "lru-cache": "^4.1.2",
-        "multiaddr": "^3.0.2",
+        "libp2p-crypto": "~0.13.0",
+        "lru-cache": "^4.1.3",
+        "multiaddr": "^5.0.0",
+        "multibase": "~0.4.0",
         "multihashes": "~0.4.13",
         "ndjson": "^1.5.0",
         "once": "^1.4.0",
-        "peer-id": "~0.10.6",
-        "peer-info": "~0.11.6",
+        "peer-id": "~0.11.0",
+        "peer-info": "~0.14.1",
         "promisify-es6": "^1.0.3",
-        "pull-defer": "^0.2.2",
+        "pull-defer": "~0.2.2",
         "pull-pushable": "^2.2.0",
+        "pull-stream-to-stream": "^1.3.4",
         "pump": "^3.0.0",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5",
-        "stream-http": "^2.8.1",
+        "qs": "^6.5.2",
+        "readable-stream": "^2.3.6",
+        "stream-http": "^2.8.3",
         "stream-to-pull-stream": "^1.7.2",
-        "streamifier": "^0.1.1",
-        "tar-stream": "^1.5.5"
+        "streamifier": "~0.1.1",
+        "tar-stream": "^1.6.1"
       },
       "dependencies": {
+        "asn1.js": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+          "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
         "big.js": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.1.2.tgz",
           "integrity": "sha512-qG6ZOc1lY84Bn8p/z9xvJisj9F4PRyo0pOGqGNYc7gS3p1WciS/3XcLuNI3Z/yYZpMNFhHeX3YNENwgrQq0NTA=="
         },
-        "ipfs-block": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
-          "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "cids": "^0.5.2"
+            "ms": "2.0.0"
           }
         },
         "ipld-dag-pb": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.13.1.tgz",
-          "integrity": "sha512-HxybRQvpY8IQ9T0bImlT5v4LBR3jJAgEnFRA/ZU2UNIiBuRkbirI9+VSX03+WkiYooiFMoZz6Qp/xYMdoogNWg==",
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.14.5.tgz",
+          "integrity": "sha512-HHKqyjP1m9PxbT1+EWrbq/dH6uIY90mvwQ6G79JWKsdCsyOvRbyCdmZmXbbuTN9JBFcoMG2684qix+HtiEz0fQ==",
           "requires": {
-            "async": "^2.6.0",
+            "async": "^2.6.1",
             "bs58": "^4.0.1",
-            "buffer-loader": "0.0.1",
-            "cids": "~0.5.2",
-            "ipfs-block": "~0.6.1",
+            "buffer-loader": "~0.0.1",
+            "cids": "~0.5.3",
+            "class-is": "^1.1.0",
             "is-ipfs": "~0.3.2",
-            "multihashes": "~0.4.12",
-            "multihashing-async": "~0.4.7",
+            "multihashes": "~0.4.13",
+            "multihashing-async": "~0.5.1",
             "protons": "^1.0.1",
-            "pull-stream": "^3.6.1",
+            "pull-stream": "^3.6.8",
             "pull-traverse": "^1.0.3",
-            "stable": "^0.1.6"
+            "stable": "~0.1.8"
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
+          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.2.0",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.8",
+            "node-forge": "^0.7.5",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "multihashing-async": {
+              "version": "0.4.8",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+              "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+              "requires": {
+                "async": "^2.6.0",
+                "blakejs": "^1.1.0",
+                "js-sha3": "^0.7.0",
+                "multihashes": "~0.4.13",
+                "murmurhash3js": "^3.0.1",
+                "nodeify": "^1.0.1"
+              }
+            }
           }
         },
         "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
+          "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
           "requires": {
             "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
             "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
             "lodash.filter": "^4.6.0",
             "lodash.map": "^4.6.0",
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
         },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
           "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
+          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
+          "requires": {
+            "async": "^2.6.1",
+            "libp2p-crypto": "~0.13.0",
+            "lodash": "^4.17.10",
+            "multihashes": "~0.4.13"
           }
         },
         "pump": {
@@ -16561,19 +16840,50 @@
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
           }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "stable": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+          "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+        },
+        "stream-http": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+          "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+          "requires": {
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.6",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#master"
         }
       }
     },
     "ipfs-bitswap": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.19.0.tgz",
-      "integrity": "sha512-TF+wi6tYaWusJatJROlKOP4XftIf4cW8YVu6+5iIZ1oezon0I5eKRwh4iRd1HtOqyRckXrGgy8mg6rvWyGpaiA==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.20.3.tgz",
+      "integrity": "sha512-qXg/QhevKBU/tKdWgW6yhcSKQDQx+4Mvv9HEeoVjkqZ9Pagmojk6yGk8X4J9H2G2PagvHXkWsqwqyKho7RcPWA==",
       "requires": {
-        "async": "^2.6.0",
-        "big.js": "^5.0.3",
-        "cids": "~0.5.2",
+        "async": "^2.6.1",
+        "big.js": "^5.1.2",
+        "cids": "~0.5.3",
         "debug": "^3.1.0",
-        "ipfs-block": "~0.6.1",
+        "ipfs-block": "~0.7.1",
         "lodash.debounce": "^4.0.8",
         "lodash.find": "^4.6.0",
         "lodash.groupby": "^4.6.0",
@@ -16584,15 +16894,14 @@
         "lodash.uniqwith": "^4.5.0",
         "lodash.values": "^4.3.0",
         "moving-average": "^1.0.0",
-        "multicodec": "~0.2.6",
-        "multihashing-async": "~0.4.7",
+        "multicodec": "~0.2.7",
+        "multihashing-async": "~0.5.1",
         "protons": "^1.0.1",
         "pull-defer": "~0.2.2",
         "pull-length-prefixed": "^1.3.0",
-        "pull-pushable": "^2.1.2",
-        "pull-stream": "^3.6.1",
-        "safe-buffer": "^5.1.1",
-        "varint-decoder": "^0.1.1"
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.8",
+        "varint-decoder": "~0.1.1"
       },
       "dependencies": {
         "big.js": {
@@ -16608,12 +16917,25 @@
             "ms": "2.0.0"
           }
         },
-        "ipfs-block": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
-          "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
+        "multicodec": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.2.7.tgz",
+          "integrity": "sha512-96xc9zs7bsclMW0Po9ERnRFqcsWHY8OZ8JW/I8DeHG58YYJZy3cBGI00Ze7hz9Ix56DNHMTSxEj9cgoZByruMg==",
           "requires": {
-            "cids": "^0.5.2"
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
+          "requires": {
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
           }
         }
       }
@@ -16628,9 +16950,9 @@
       }
     },
     "ipfs-block-service": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.13.0.tgz",
-      "integrity": "sha512-fKKEF47oOSTV4S0X12FPqtfxBRL1/BZF+AzIzpfuTXer7ikStn02quUs2mz0Hfn5I0BjCuDGbJEnzca4m6EpQg=="
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.14.0.tgz",
+      "integrity": "sha512-qu5VdBSAh/44wtqVgyoyWebjIY6mLbiEZObwYZHEZ5VFuU4oOlfZ+s2oz2I5lTw1eeL7SGccQeshQ0OePxIPnw=="
     },
     "ipfs-http-response": {
       "version": "0.1.2",
@@ -16661,6 +16983,71 @@
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
           "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
+        }
+      }
+    },
+    "ipfs-mfs": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.1.2.tgz",
+      "integrity": "sha512-tm6D9Z3X5HwneZKxrt+hgU5zkKZs44aihD6VYA8ZBaEiuoNoLjzasL5v/ICMT68HY2Eg7qqfPUjKnLjGjR5kGw==",
+      "requires": {
+        "async": "^2.6.1",
+        "blob": "~0.0.4",
+        "bs58": "^4.0.1",
+        "cids": "~0.5.3",
+        "debug": "^3.1.0",
+        "detect-node": "^2.0.3",
+        "file-api": "~0.10.4",
+        "filereader-stream": "^2.0.0",
+        "interface-datastore": "~0.4.2",
+        "ipfs-unixfs": "~0.1.15",
+        "ipfs-unixfs-engine": "~0.30.0",
+        "is-pull-stream": "~0.0.0",
+        "is-stream": "^1.1.0",
+        "joi": "^13.4.0",
+        "joi-browser": "^13.4.0",
+        "mortice": "^1.2.0",
+        "once": "^1.4.0",
+        "promisify-es6": "^1.0.3",
+        "pull-cat": "^1.1.11",
+        "pull-paramap": "^1.2.2",
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.7",
+        "pull-stream-to-stream": "^1.3.4",
+        "pull-traverse": "^1.0.3",
+        "stream-to-pull-stream": "^1.7.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
+        },
+        "joi": {
+          "version": "13.4.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.4.0.tgz",
+          "integrity": "sha512-JuK4GjEu6j7zr9FuVe2MAseZ6si/8/HaY0qMAejfDFHp7jcH4OKE937mIHM5VT4xDS0q7lpQbszbxKV9rm0yUg==",
+          "requires": {
+            "hoek": "5.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
+        },
+        "topo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+          "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+          "requires": {
+            "hoek": "5.x.x"
+          }
         }
       }
     },
@@ -16707,37 +17094,28 @@
       }
     },
     "ipfs-repo": {
-      "version": "0.18.7",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.18.7.tgz",
-      "integrity": "sha512-a1gXPX2UA/8rE63/E5X7+QB7jvmNYD+mVHSX0ypb7ZIsMoc0ewiq5Bwc2NXQAN7PCNWksxp1tDGWzq6bAPm9vg==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.22.1.tgz",
+      "integrity": "sha512-57RAHqbMMcVLEkbzx6PlMs7LnwsfMJrzjjNCNAsQuN2wcT8Abm09UIjo2P36x0leYMNIG2SWiyr1H5OLSKn74Q==",
       "requires": {
         "async": "^2.6.0",
         "base32.js": "~0.1.0",
         "big.js": "^5.0.3",
-        "cids": "~0.5.2",
+        "cids": "~0.5.3",
         "datastore-core": "~0.4.0",
-        "datastore-fs": "~0.4.2",
-        "datastore-level": "~0.7.0",
+        "datastore-fs": "~0.5.0",
+        "datastore-level": "~0.8.0",
         "debug": "^3.1.0",
         "interface-datastore": "~0.4.2",
-        "ipfs-block": "~0.6.1",
-        "leveldown": "^1.7.2",
-        "lock-me": "^1.0.3",
+        "ipfs-block": "~0.7.1",
+        "lock-me": "^1.0.4",
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
         "lodash.set": "^4.3.2",
-        "multiaddr": "^3.0.1",
-        "pull-stream": "^3.6.1"
+        "multiaddr": "^4.0.0",
+        "pull-stream": "^3.6.7"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
-          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
         "big.js": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.1.2.tgz",
@@ -16749,37 +17127,6 @@
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "ipfs-block": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
-          "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
-          "requires": {
-            "cids": "^0.5.2"
-          }
-        },
-        "level-js": {
-          "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
-          "from": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
-          "requires": {
-            "abstract-leveldown": "~2.4.1",
-            "idb-readable-stream": "0.0.4",
-            "ltgt": "^2.1.2",
-            "xtend": "^4.0.1"
-          }
-        },
-        "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "ip": "^1.1.5",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
           }
         }
       }
@@ -16793,21 +17140,21 @@
       }
     },
     "ipfs-unixfs-engine": {
-      "version": "0.24.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.24.4.tgz",
-      "integrity": "sha512-dioocJXylmdWRMUR/9WqRn8EYOj0VGrSYFTTdy2Z2WJdOGhnb+C+ubkGTyewmkAFDWoxaqCcwwPRbos3PjqIUQ==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.30.1.tgz",
+      "integrity": "sha512-UU9mzeK73PhhGoDDcNLBO1//3zJmREOiQZOVvI57m/igQpxB8GdxdEb/laolNLpY9oFFugV7IDiZ7KsRMMoCZQ==",
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
         "bs58": "^4.0.1",
-        "cids": "~0.5.2",
-        "deep-extend": "~0.5.0",
-        "ipfs-unixfs": "~0.1.14",
-        "ipld": "^0.15.0",
-        "ipld-dag-pb": "~0.13.1",
-        "left-pad": "^1.2.0",
-        "lodash": "^4.17.5",
+        "cids": "~0.5.3",
+        "deep-extend": "~0.6.0",
+        "ipfs-unixfs": "~0.1.15",
+        "ipld": "~0.17.2",
+        "ipld-dag-pb": "~0.14.4",
+        "left-pad": "^1.3.0",
+        "lodash": "^4.17.10",
         "multihashes": "~0.4.13",
-        "multihashing-async": "~0.4.8",
+        "multihashing-async": "~0.5.1",
         "pull-batch": "^1.0.0",
         "pull-block": "^1.4.0",
         "pull-cat": "^1.1.11",
@@ -16815,111 +17162,104 @@
         "pull-paramap": "^1.2.2",
         "pull-pause": "0.0.2",
         "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.2",
+        "pull-stream": "^3.6.8",
+        "pull-through": "^1.0.18",
         "pull-traverse": "^1.0.3",
         "pull-write": "^1.1.4",
         "sparse-array": "^1.3.1"
       },
       "dependencies": {
-        "deep-extend": {
+        "multihashing-async": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
-        },
-        "ipfs-block": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
-          "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
           "requires": {
-            "cids": "^0.5.2"
-          }
-        },
-        "ipld-dag-pb": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.13.1.tgz",
-          "integrity": "sha512-HxybRQvpY8IQ9T0bImlT5v4LBR3jJAgEnFRA/ZU2UNIiBuRkbirI9+VSX03+WkiYooiFMoZz6Qp/xYMdoogNWg==",
-          "requires": {
-            "async": "^2.6.0",
-            "bs58": "^4.0.1",
-            "buffer-loader": "0.0.1",
-            "cids": "~0.5.2",
-            "ipfs-block": "~0.6.1",
-            "is-ipfs": "~0.3.2",
-            "multihashes": "~0.4.12",
-            "multihashing-async": "~0.4.7",
-            "protons": "^1.0.1",
-            "pull-stream": "^3.6.1",
-            "pull-traverse": "^1.0.3",
-            "stable": "^0.1.6"
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
           }
         }
       }
     },
     "ipld": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.15.0.tgz",
-      "integrity": "sha512-/7aeDrd/SRBerJNAmGzWA2Iu61IQrkIJ4tiU0Sf/ZZeawuIIriH5KhQyFnPiTZk8a5tcEnCoqhzh6N++zpFccQ==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.17.3.tgz",
+      "integrity": "sha512-nUWbYfB59PTf/Hq0OEnitbR2hQb7k8/DOINpR6dXQ9MXVWh1cKxGs3ENOHuRr944T/ge2cJwI3XertcWqm0lXg==",
       "requires": {
-        "async": "^2.6.0",
-        "cids": "~0.5.2",
+        "async": "^2.6.1",
+        "cids": "~0.5.3",
         "interface-datastore": "~0.4.2",
-        "ipfs-block": "~0.6.1",
-        "ipfs-block-service": "~0.13.0",
-        "ipfs-repo": "~0.18.5",
-        "ipld-bitcoin": "~0.1.5",
-        "ipld-dag-cbor": "~0.12.0",
-        "ipld-dag-pb": "~0.13.0",
-        "ipld-ethereum": "^2.0.0",
-        "ipld-git": "~0.2.0",
-        "ipld-raw": "^2.0.0",
-        "ipld-zcash": "~0.1.3",
+        "ipfs-block": "~0.7.1",
+        "ipfs-block-service": "~0.14.0",
+        "ipfs-repo": "~0.22.1",
+        "ipld-bitcoin": "~0.1.6",
+        "ipld-dag-cbor": "~0.12.1",
+        "ipld-dag-pb": "~0.14.5",
+        "ipld-ethereum": "^2.0.1",
+        "ipld-git": "~0.2.1",
+        "ipld-raw": "^2.0.1",
+        "ipld-zcash": "~0.1.4",
         "is-ipfs": "~0.3.2",
         "lodash.flatten": "^4.4.0",
         "lodash.includes": "^4.3.0",
-        "memdown": "^1.4.1",
-        "multihashes": "~0.4.12",
-        "pull-defer": "^0.2.2",
+        "memdown": "^3.0.0",
+        "multihashes": "~0.4.13",
+        "pull-defer": "~0.2.2",
         "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.1",
+        "pull-stream": "^3.6.8",
         "pull-traverse": "^1.0.3"
       },
       "dependencies": {
-        "ipfs-block": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
-          "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
+        "ipld-dag-pb": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.14.5.tgz",
+          "integrity": "sha512-HHKqyjP1m9PxbT1+EWrbq/dH6uIY90mvwQ6G79JWKsdCsyOvRbyCdmZmXbbuTN9JBFcoMG2684qix+HtiEz0fQ==",
           "requires": {
-            "cids": "^0.5.2"
+            "async": "^2.6.1",
+            "bs58": "^4.0.1",
+            "buffer-loader": "~0.0.1",
+            "cids": "~0.5.3",
+            "class-is": "^1.1.0",
+            "is-ipfs": "~0.3.2",
+            "multihashes": "~0.4.13",
+            "multihashing-async": "~0.5.1",
+            "protons": "^1.0.1",
+            "pull-stream": "^3.6.8",
+            "pull-traverse": "^1.0.3",
+            "stable": "~0.1.8"
           }
         },
-        "ipld-dag-pb": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.13.1.tgz",
-          "integrity": "sha512-HxybRQvpY8IQ9T0bImlT5v4LBR3jJAgEnFRA/ZU2UNIiBuRkbirI9+VSX03+WkiYooiFMoZz6Qp/xYMdoogNWg==",
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
           "requires": {
-            "async": "^2.6.0",
-            "bs58": "^4.0.1",
-            "buffer-loader": "0.0.1",
-            "cids": "~0.5.2",
-            "ipfs-block": "~0.6.1",
-            "is-ipfs": "~0.3.2",
-            "multihashes": "~0.4.12",
-            "multihashing-async": "~0.4.7",
-            "protons": "^1.0.1",
-            "pull-stream": "^3.6.1",
-            "pull-traverse": "^1.0.3",
-            "stable": "^0.1.6"
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
           }
+        },
+        "stable": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+          "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
         }
       }
     },
     "ipld-bitcoin": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.1.6.tgz",
-      "integrity": "sha512-WqF3u8nEsk94dfpTZUHXHlnscWBSTs8i02VpJmWIjugcqYZeZzjgeMS5Q2dNTDNzuKshmvjQJa3ubpSkWo3XwA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.1.7.tgz",
+      "integrity": "sha512-tH0nA2PLaLPjFJFY8aKNGEiE/X3FAIoAmYQZKv9d2TZFMF2n4kjhxZbLZPHZ9Lc+rjOxG2sym4HPylls69eeCw==",
       "requires": {
         "bitcoinjs-lib": "^3.3.2",
         "cids": "~0.5.2",
+        "git-validate": "^2.2.2",
         "multihashes": "~0.4.12",
         "multihashing-async": "~0.5.1"
       },
@@ -16989,15 +17329,14 @@
       }
     },
     "ipld-ethereum": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.0.tgz",
-      "integrity": "sha512-wpWmba4bwjctTrHZbYQIdbizCBprEh4ueDhAJtYiiaEoDA4yWdrDF/gHNL3dBXFMFZ/FYudSI08GrQeEuC8tQg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.1.tgz",
+      "integrity": "sha512-p+OIsTg7+NeXnE2Uq7g5HV7KVbJTQ9kVHSywOAUxUfj6loJb+6ReTCRrayQ+SbIXuVVVIVPU8OOUoGaugwFEjg==",
       "requires": {
         "async": "^2.6.0",
         "cids": "~0.5.2",
-        "eth-hash-to-cid": "~0.1.0",
         "ethereumjs-account": "^2.0.4",
-        "ethereumjs-block": "^1.7.0",
+        "ethereumjs-block": "^1.7.1",
         "ethereumjs-tx": "^1.3.3",
         "ipfs-block": "~0.6.1",
         "merkle-patricia-tree": "^2.2.0",
@@ -17070,9 +17409,9 @@
       }
     },
     "ipld-zcash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.1.4.tgz",
-      "integrity": "sha512-KjwuRH0VHPY+SPjTD1lYL3XzMfQyIeCRH+Jkq1z5kSmX0IjNe4riVzUPGySD+R1ITewSDGvnCoTeyNwK/dIrEg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.1.5.tgz",
+      "integrity": "sha512-e8Fs85G7e7fzB9gWL4dRNxSro/Qz42PZwV//oogBRaFF1LOz0pKd/5uJy3Utvd1AgR5EcdnD2nngq+wZ58kSdA==",
       "requires": {
         "cids": "~0.5.2",
         "dirty-chai": "^2.0.1",
@@ -17658,11 +17997,6 @@
       "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
       "dev": true
     },
-    "isbuffer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz",
-      "integrity": "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s="
-    },
     "isemail": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
@@ -17750,35 +18084,12 @@
       "integrity": "sha512-TfzJd2JaJ/lg/gU+q5j9rLAjnfUNF9DUmXTP9w+GfmG79LjFOXFeM7hIFuXCBcZCivUDFwd9l1btTV9rhHumtQ=="
     },
     "joi-multiaddr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-1.0.1.tgz",
-      "integrity": "sha512-Ye5bCPQZ3Jl8zSaiBwKjBiZf3dM9PIrvWizrOecwRlbWpGWt0kPK5PunOMm/nAdVIOwQIR1Z2/sGMe3u+vrCGA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-2.0.0.tgz",
+      "integrity": "sha512-7dJLwgplwRnIQAlC+zTuX3jkk3uXVa/RKm7GDfNO3NqmjiYgwAet8yprIdilki1WhdkJJMLuTNDf49uFNru68A==",
       "requires": {
-        "mafmt": "^4.0.0",
-        "multiaddr": "^3.0.2"
-      },
-      "dependencies": {
-        "mafmt": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-4.0.0.tgz",
-          "integrity": "sha512-zTqHhC9UUYlOkTwOXkdNqCE5U7vuz5UzlRJa4Et3ddCu/Sq36Z8F9mWCGdoqzahDcnRiGc515XjsnkAQHdH55g==",
-          "requires": {
-            "multiaddr": "^3.0.2"
-          }
-        },
-        "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "ip": "^1.1.5",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        }
+        "mafmt": "^6.0.0",
+        "multiaddr": "^4.0.0"
       }
     },
     "js-base64": {
@@ -18105,11 +18416,10 @@
       }
     },
     "k-bucket": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-3.3.1.tgz",
-      "integrity": "sha512-kgwWqYT79rAahn4maIVTP8dIe+m1KulufWW+f1bB9DlZrRFiGpZ4iJOg2HUp4xJYBWONP3+rOPIWF/RXABU6mw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-4.0.1.tgz",
+      "integrity": "sha512-YvDpmY3waI999h1zZoW1rJ04fZrgZ+5PAlVmvwDHT6YO/Q1AOhdel07xsKy9eAvJjQ9xZV1wz3rXKqEfaWvlcQ==",
       "requires": {
-        "buffer-equals": "^1.0.3",
         "inherits": "^2.0.1",
         "randombytes": "^2.0.3"
       }
@@ -18824,6 +19134,15 @@
       "integrity": "sha512-nQRpMcHm1cQ6gmztdvLcIvxocznSMqH/y6XtERrWrHaymOYdDGroRqetJvJycxGEr1aakXiigDgn7JnzuXlk6A==",
       "dev": true
     },
+    "latency-monitor": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/latency-monitor/-/latency-monitor-0.2.1.tgz",
+      "integrity": "sha1-QEPV8j3obiv872ztSjtbki4d1+0=",
+      "requires": {
+        "debug": "^2.6.0",
+        "lodash": "^4.17.4"
+      }
+    },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
@@ -18892,49 +19211,45 @@
       }
     },
     "level-codec": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.0.tgz",
+      "integrity": "sha512-OIpVvjCcZNP5SdhcNupnsI1zo5Y9Vpm+k/F1gfG5kXrtctlrwanisakweJtE0uA0OpLukRfOQae+Fg0M5Debhg=="
     },
     "level-errors": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.0.tgz",
+      "integrity": "sha512-AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==",
       "requires": {
         "errno": "~0.1.1"
       }
     },
     "level-iterator-stream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+      "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
       "requires": {
         "inherits": "^2.0.1",
-        "level-errors": "^1.0.3",
-        "readable-stream": "^1.0.33",
+        "readable-stream": "^2.0.5",
         "xtend": "^4.0.0"
+      }
+    },
+    "level-js": {
+      "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
+      "from": "github:timkuijsten/level.js#idbunwrapper",
+      "requires": {
+        "abstract-leveldown": "~2.4.1",
+        "idb-readable-stream": "0.0.4",
+        "ltgt": "^2.1.2",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+        "abstract-leveldown": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
+          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "xtend": "~4.0.0"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -18979,50 +19294,45 @@
       }
     },
     "leveldown": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.9.0.tgz",
-      "integrity": "sha512-3MwcrnCUIuFiKp/jSrG1UqDTV4k1yH8f5HH6T9dpqCKG+lRxcfo2KwAqbzTT+TTKfCbaATeHMy9mm1y6sI3ZvA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
+      "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
       "requires": {
-        "abstract-leveldown": "~2.7.0",
+        "abstract-leveldown": "~4.0.0",
         "bindings": "~1.3.0",
         "fast-future": "~1.0.2",
-        "nan": "~2.7.0",
-        "prebuild-install": "^2.1.0"
+        "nan": "~2.10.0",
+        "prebuild-install": "^4.0.0"
       },
       "dependencies": {
         "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "requires": {
             "xtend": "~4.0.0"
           }
-        },
-        "nan": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
         }
       }
     },
     "levelup": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
+      "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
       "requires": {
-        "deferred-leveldown": "~1.2.1",
-        "level-codec": "~7.0.0",
-        "level-errors": "~1.0.3",
-        "level-iterator-stream": "~1.3.0",
-        "prr": "~1.0.1",
-        "semver": "~5.4.1",
+        "deferred-leveldown": "~3.0.0",
+        "level-errors": "~1.1.0",
+        "level-iterator-stream": "~2.0.0",
         "xtend": "~4.0.0"
       },
       "dependencies": {
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        "level-errors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
+          "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
+          "requires": {
+            "errno": "~0.1.1"
+          }
         }
       }
     },
@@ -19067,73 +19377,122 @@
       }
     },
     "libp2p": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.18.0.tgz",
-      "integrity": "sha512-gC5TNB3atM5Tc14CFu14IEAqm/v9ZJA3XuCX+kbZfcTZiNbMiIFTZrQY4UY/0mx7ZEpDTJn/fGwI8OIc0EYJRQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.22.0.tgz",
+      "integrity": "sha512-7CcituMkZc4OcsXs1yjBnLDCjXl3OlDB6A6NgjRLOWplb2VnyR1RSU4kpUmslcE7BvKKNqSeDd/QzBwcPp7prg==",
       "requires": {
-        "async": "^2.6.0",
-        "libp2p-floodsub": "^0.14.1",
-        "libp2p-ping": "~0.6.1",
-        "libp2p-switch": "~0.36.1",
-        "mafmt": "^4.0.0",
-        "multiaddr": "^3.0.2",
-        "peer-book": "~0.5.4",
-        "peer-id": "~0.10.6",
-        "peer-info": "~0.11.6"
+        "async": "^2.6.1",
+        "joi": "^13.4.0",
+        "joi-browser": "^13.4.0",
+        "libp2p-connection-manager": "~0.0.2",
+        "libp2p-floodsub": "~0.15.0",
+        "libp2p-ping": "~0.8.0",
+        "libp2p-switch": "~0.40.4",
+        "libp2p-websockets": "~0.12.0",
+        "mafmt": "^6.0.0",
+        "multiaddr": "^5.0.0",
+        "peer-book": "~0.8.0",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1"
       },
       "dependencies": {
-        "mafmt": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-4.0.0.tgz",
-          "integrity": "sha512-zTqHhC9UUYlOkTwOXkdNqCE5U7vuz5UzlRJa4Et3ddCu/Sq36Z8F9mWCGdoqzahDcnRiGc515XjsnkAQHdH55g==",
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
+        },
+        "joi": {
+          "version": "13.4.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.4.0.tgz",
+          "integrity": "sha512-JuK4GjEu6j7zr9FuVe2MAseZ6si/8/HaY0qMAejfDFHp7jcH4OKE937mIHM5VT4xDS0q7lpQbszbxKV9rm0yUg==",
           "requires": {
-            "multiaddr": "^3.0.2"
+            "hoek": "5.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
           }
         },
         "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
+          "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
           "requires": {
             "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
             "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
             "lodash.filter": "^4.6.0",
             "lodash.map": "^4.6.0",
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
         },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
+        "topo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+          "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
           "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
+            "hoek": "5.x.x"
+          }
+        }
+      }
+    },
+    "libp2p-bootstrap": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.9.3.tgz",
+      "integrity": "sha512-rEVvZZCKmoJlfgSMk7JkuvsdKGpLkoPK3U47xtT+pNJC+p/LZcjSmGwxNwwJvgg3jTuy2sl23W6JRZ26AXv7Og==",
+      "requires": {
+        "async": "^2.6.1",
+        "debug": "^3.1.0",
+        "mafmt": "^6.0.0",
+        "multiaddr": "^5.0.0",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "multiaddr": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
+          "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
+          "requires": {
+            "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
+            "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
+            "lodash.filter": "^4.6.0",
+            "lodash.map": "^4.6.0",
+            "varint": "^5.0.0",
+            "xtend": "^4.0.1"
           }
         }
       }
     },
     "libp2p-circuit": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.1.5.tgz",
-      "integrity": "sha512-0aUhyceJjpmB+lo0InYuzLP5NPWjkdga8LoZ0Gw1Qm+ghPOXk/plPBUH4urLT84H10aPb/OETyG9i1+uQQPxFA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.2.0.tgz",
+      "integrity": "sha512-K3k+ojqO8b1VM1C2Nb+ba+8z7lDD1pn6stieIB3pOEB35M9pVbXfVg8nKoSnjw3NAXCSsSCbD1swYMwq8g/fAA==",
       "requires": {
         "assert": "^1.4.1",
         "async": "^2.6.0",
         "debug": "^3.1.0",
         "interface-connection": "^0.3.2",
         "lodash": "^4.17.5",
-        "mafmt": "^4.0.0",
-        "multiaddr": "^3.0.2",
+        "mafmt": "^6.0.0",
+        "multiaddr": "^4.0.0",
         "multistream-select": "^0.14.1",
-        "peer-id": "^0.10.6",
-        "peer-info": "^0.11.6",
+        "peer-id": "^0.10.7",
+        "peer-info": "^0.14.0",
         "protons": "^1.0.1",
         "pull-abortable": "^4.1.1",
         "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.2",
+        "pull-stream": "^3.6.7",
         "safe-buffer": "^5.1.1",
         "setimmediate": "^1.0.5"
       },
@@ -19145,36 +19504,24 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "mafmt": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-4.0.0.tgz",
-          "integrity": "sha512-zTqHhC9UUYlOkTwOXkdNqCE5U7vuz5UzlRJa4Et3ddCu/Sq36Z8F9mWCGdoqzahDcnRiGc515XjsnkAQHdH55g==",
-          "requires": {
-            "multiaddr": "^3.0.2"
-          }
-        },
-        "multiaddr": {
+        }
+      }
+    },
+    "libp2p-connection-manager": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/libp2p-connection-manager/-/libp2p-connection-manager-0.0.2.tgz",
+      "integrity": "sha512-G/OzMfxQe0lHx7ujibPqpFLCeMN9I5vNH0+Rs9zat6+uIT51Saupx95lyoyh5J8nh93ui2cNH7PQnwJMZVKa1A==",
+      "requires": {
+        "debug": "^3.1.0",
+        "latency-monitor": "^0.2.1"
+      },
+      "dependencies": {
+        "debug": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "bs58": "^4.0.1",
-            "ip": "^1.1.5",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
-          "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
+            "ms": "2.0.0"
           }
         }
       }
@@ -19229,21 +19576,31 @@
       }
     },
     "libp2p-floodsub": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.14.1.tgz",
-      "integrity": "sha512-MxdKgD/1dWlQjT4WVlirAHq0QAczGjC/P0SLpoYRna/RZqEmkOuiJfUEwqWWZXENVBuyQep8Ry3yLKt67xJfVg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.15.0.tgz",
+      "integrity": "sha512-sDVNxE6GKOZ7+qWE06jQuJ/CrYgPfOqkRD4qWPFe02AtghswyocWJkDiceKHx++mW2h2KYl7ae68XK0DLEEOiw==",
       "requires": {
         "async": "^2.6.0",
         "bs58": "^4.0.1",
         "debug": "^3.1.0",
-        "length-prefixed-stream": "^1.5.1",
-        "libp2p-crypto": "~0.12.1",
+        "length-prefixed-stream": "^1.5.2",
+        "libp2p-crypto": "~0.13.0",
         "lodash.values": "^4.3.0",
         "protons": "^1.0.1",
-        "pull-pushable": "^2.1.2",
+        "pull-pushable": "^2.2.0",
         "time-cache": "~0.3.0"
       },
       "dependencies": {
+        "asn1.js": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+          "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -19251,74 +19608,104 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "libp2p-crypto": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
+          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.2.0",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.8",
+            "node-forge": "^0.7.5",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#master"
         }
       }
     },
     "libp2p-identify": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.6.3.tgz",
-      "integrity": "sha512-tCkobHxmK636lCF3PwIA/G8Ty7KGFVT/WW7zaNUUypMKJKT9gZg9U1d+BVTM2xA4TUYSnt8TTY6WgKeUfDffHg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.1.tgz",
+      "integrity": "sha512-uQh04s5s2v6JbhdzeKdQqaOGmEMlZv60djMR74MPkerNPFLcJEHHyVXcD35CgMVaZezqai2Y8L2zvPuuOnUZtA==",
       "requires": {
-        "multiaddr": "^3.0.2",
-        "peer-id": "~0.10.5",
-        "peer-info": "~0.11.6",
+        "multiaddr": "^5.0.0",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1",
         "protons": "^1.0.1",
         "pull-length-prefixed": "^1.3.0",
-        "pull-stream": "^3.6.1"
+        "pull-stream": "^3.6.7"
       },
       "dependencies": {
         "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
+          "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
           "requires": {
             "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
             "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
             "lodash.filter": "^4.6.0",
             "lodash.map": "^4.6.0",
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
-          }
-        },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
-          "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
           }
         }
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.8.0.tgz",
-      "integrity": "sha512-eVpOFz2nvAG/zcusWSU2uBQFyD+jbmDIXOtdAlYDJiwKvXkfZ3wWmzmePEaM+vzr/zI2srtWH0WeMMJkR7HgkQ==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.10.1.tgz",
+      "integrity": "sha512-1Ao1Xns75cBd1nIQ2cIEVrg5mEne07x1aAosuXnklqy5arYYPghe5AqdcheGJ2Dm+mWABbULwpClTs/QjV3o0w==",
       "requires": {
-        "async": "^2.6.0",
-        "base32.js": "^0.1.0",
-        "cids": "~0.5.2",
+        "async": "^2.6.1",
+        "base32.js": "~0.1.0",
+        "cids": "~0.5.3",
         "debug": "^3.1.0",
         "hashlru": "^2.2.1",
-        "heap": "^0.2.6",
+        "heap": "~0.2.6",
         "interface-datastore": "~0.4.2",
-        "k-bucket": "^3.3.1",
-        "libp2p-crypto": "~0.12.0",
+        "k-bucket": "^4.0.1",
+        "libp2p-crypto": "~0.13.0",
         "libp2p-record": "~0.5.1",
-        "multihashing-async": "~0.4.7",
-        "peer-id": "~0.10.5",
-        "peer-info": "~0.11.6",
-        "priorityqueue": "^0.2.0",
+        "multihashing-async": "~0.5.1",
+        "peer-id": "~0.11.0",
+        "peer-info": "~0.14.1",
+        "priorityqueue": "~0.2.1",
         "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.0",
-        "pull-stream": "^3.6.1",
-        "safe-buffer": "^5.1.1",
+        "pull-length-prefixed": "^1.3.1",
+        "pull-stream": "^3.6.8",
         "varint": "^5.0.0",
         "xor-distance": "^1.0.0"
       },
       "dependencies": {
+        "asn1.js": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+          "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -19327,28 +19714,73 @@
             "ms": "2.0.0"
           }
         },
-        "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+        "libp2p-crypto": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
+          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
           "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.2.0",
             "bs58": "^4.0.1",
-            "ip": "^1.1.5",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.8",
+            "node-forge": "^0.7.5",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "multihashing-async": {
+              "version": "0.4.8",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+              "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+              "requires": {
+                "async": "^2.6.0",
+                "blakejs": "^1.1.0",
+                "js-sha3": "^0.7.0",
+                "multihashes": "~0.4.13",
+                "murmurhash3js": "^3.0.1",
+                "nodeify": "^1.0.1"
+              }
+            }
           }
         },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
           "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
           }
+        },
+        "peer-id": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
+          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
+          "requires": {
+            "async": "^2.6.1",
+            "libp2p-crypto": "~0.13.0",
+            "lodash": "^4.17.10",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#master"
         }
       }
     },
@@ -19366,102 +19798,53 @@
       }
     },
     "libp2p-mdns": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.9.2.tgz",
-      "integrity": "sha512-g77yK3znf4bZl6466EOs1MGP9Pqv4gEcsCnuDaSiWtZ4bZOApkGS/gWQBY3vaCbP1faJ5m7b83uBlEeHiT61cA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.12.0.tgz",
+      "integrity": "sha512-2K1IT8ZwnzS00Ws6MiLW89W2KAG+8NsrMez2laVZJtD9RpWBgc9+KGQ7KU1nYRyYXD/NGXNEiQ6HTkhSQvYbiQ==",
       "requires": {
-        "libp2p-tcp": "~0.11.2",
-        "multiaddr": "^3.0.2",
-        "multicast-dns": "^6.2.3",
-        "peer-id": "~0.10.5",
-        "peer-info": "~0.11.6"
+        "libp2p-tcp": "~0.12.0",
+        "multiaddr": "^5.0.0",
+        "multicast-dns": "^7.0.0",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1"
       },
       "dependencies": {
         "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
+          "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
           "requires": {
             "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
             "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
             "lodash.filter": "^4.6.0",
             "lodash.map": "^4.6.0",
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
-        },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
-          "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
-          }
         }
       }
     },
-    "libp2p-multiplex": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/libp2p-multiplex/-/libp2p-multiplex-0.5.1.tgz",
-      "integrity": "sha512-XZagf1B31Vkbd+iAai8cOfRkcZWba+MtSRf/xQJ7uOz7O4heLMNC4orcDqT0n+Hkkn3zfqllH75Kp1xJ+Vog2w==",
+    "libp2p-mplex": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.8.0.tgz",
+      "integrity": "sha512-bjpHYqyxYNsnyKRgeATVU8u1wnP1vV/rEL+TOuVCv9WBnUPBifL9e+ggbEQtIQfZDsiDl3l43i8MJDuRKOag7A==",
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
+        "chunky": "0.0.0",
+        "concat-stream": "^1.6.2",
+        "debug": "^3.1.0",
+        "duplexify": "^3.6.0",
+        "interface-connection": "~0.3.2",
         "pull-catch": "^1.0.0",
-        "pull-stream": "^3.6.1",
+        "pull-stream": "^3.6.8",
         "pull-stream-to-stream": "^1.3.4",
-        "pump": "^2.0.0",
-        "stream-to-pull-stream": "^1.7.2"
-      },
-      "dependencies": {
-        "multiplex": {
-          "version": "github:dignifiedquire/multiplex#b5d5edd30454e2c978ee8c52df86f5f4840d2eab",
-          "from": "github:dignifiedquire/multiplex#b5d5edd30454e2c978ee8c52df86f5f4840d2eab",
-          "requires": {
-            "debug": "^2.6.1",
-            "duplexify": "^3.4.2",
-            "readable-stream": "^2.0.2",
-            "varint": "^4.0.0"
-          }
-        },
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "varint": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-4.0.1.tgz",
-          "integrity": "sha1-SQgpuULSSEY7KzUJeZXDv3NxmOk="
-        }
-      }
-    },
-    "libp2p-ping": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.6.1.tgz",
-      "integrity": "sha512-1u+77pedHwEqGp4LELBsYtjXrZSmXMGoPpfNAXLq0jyai4F54rvDAMin78VQlYbvNB2oz10KrOD34IlV3Cna1w==",
-      "requires": {
-        "libp2p-crypto": "~0.12.1",
-        "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.1"
-      }
-    },
-    "libp2p-railing": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/libp2p-railing/-/libp2p-railing-0.7.1.tgz",
-      "integrity": "sha512-IrmBwIhaXpeTMCSoJTTtUPUumO/tQdTV9cmc98rEm+dgJ9Lfl7LgOMQWUdBAcqUC2mrFmBElAphV19DR7jYU1g==",
-      "requires": {
-        "async": "^2.5.0",
-        "debug": "^3.0.1",
-        "lodash": "^4.17.4",
-        "multiaddr": "^3.0.1",
-        "peer-id": "~0.10.1",
-        "peer-info": "~0.11.0"
+        "pump": "^3.0.0",
+        "readable-stream": "^2.3.6",
+        "stream-to-pull-stream": "^1.7.2",
+        "through2": "^2.0.3",
+        "varint": "^5.0.0"
       },
       "dependencies": {
         "debug": {
@@ -19472,28 +19855,65 @@
             "ms": "2.0.0"
           }
         },
-        "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "requires": {
-            "bs58": "^4.0.1",
-            "ip": "^1.1.5",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "libp2p-ping": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.0.tgz",
+      "integrity": "sha512-7GtCCvbs6sEabnjh2ZIdru8wuKP4Qux6alw7wuaMosqWkPeFnnFmQsGaWEGpwEmD49A1dsT+aIYvAx5jFB02Bw==",
+      "requires": {
+        "libp2p-crypto": "~0.13.0",
+        "pull-handshake": "^1.1.4",
+        "pull-stream": "^3.6.7"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+          "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
+        "libp2p-crypto": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
+          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
           "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.2.0",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.8",
+            "node-forge": "^0.7.5",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#master"
         }
       }
     },
@@ -19512,17 +19932,17 @@
       }
     },
     "libp2p-secio": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.9.4.tgz",
-      "integrity": "sha512-tbeOi5pk+eSTrOmE8dB/3cEaNATAkpOktwTKGuY72azBepcJWW2d9etAUTJMUGM6GAcf8kqenI8ZarcCz6Eydg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.10.0.tgz",
+      "integrity": "sha512-/0nirr4UBdQBbETBliGYD6mLzKl+ZUX+2Kzmpk98Pdjdam5W2IhLF8zSeeK6Z4d/gJOaLdf2H8C6wLrwOSil8A==",
       "requires": {
         "async": "^2.6.0",
         "debug": "^3.1.0",
         "interface-connection": "~0.3.2",
         "libp2p-crypto": "~0.12.1",
         "multihashing-async": "~0.4.8",
-        "peer-id": "~0.10.6",
-        "peer-info": "^0.11.6",
+        "peer-id": "~0.10.7",
+        "peer-info": "^0.14.0",
         "protons": "^1.0.1",
         "pull-defer": "^0.2.2",
         "pull-handshake": "^1.1.4",
@@ -19537,52 +19957,37 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "ip": "^1.1.5",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
-          "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
-          }
         }
       }
     },
     "libp2p-switch": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.36.1.tgz",
-      "integrity": "sha512-rVlxKQJ0h5W7T2ugpwyE8KaCUZJ9lLJVxwCCMV3tkc6ziF0L/lREIfM731yJS9ubdUyRFTgn6F2RlgcTwqfd4A==",
+      "version": "0.40.6",
+      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.40.6.tgz",
+      "integrity": "sha512-2nnvaH8o1Mn7lBkR/p9eB6brRPRd4g/pbm9eRrSwdK0J5Dq8f6ps3u6NYm4DuftfEiWbJOrsm0EwAa/lC34FPg==",
       "requires": {
         "async": "^2.6.0",
+        "big.js": "^5.1.2",
         "debug": "^3.1.0",
+        "hashlru": "^2.2.1",
         "interface-connection": "~0.3.2",
         "ip-address": "^5.8.9",
-        "libp2p-circuit": "~0.1.4",
-        "libp2p-identify": "~0.6.3",
+        "libp2p-circuit": "~0.2.0",
+        "libp2p-identify": "~0.7.1",
         "lodash.includes": "^4.3.0",
-        "multiaddr": "^3.0.2",
-        "multistream-select": "~0.14.1",
+        "moving-average": "^1.0.0",
+        "multiaddr": "^5.0.0",
+        "multistream-select": "~0.14.2",
         "once": "^1.4.0",
-        "peer-id": "~0.10.6",
-        "peer-info": "~0.11.6",
-        "pull-stream": "^3.6.1"
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1",
+        "pull-stream": "^3.6.7"
       },
       "dependencies": {
+        "big.js": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.1.2.tgz",
+          "integrity": "sha512-qG6ZOc1lY84Bn8p/z9xvJisj9F4PRyo0pOGqGNYc7gS3p1WciS/3XcLuNI3Z/yYZpMNFhHeX3YNENwgrQq0NTA=="
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -19592,42 +19997,35 @@
           }
         },
         "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
+          "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
           "requires": {
             "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
             "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
             "lodash.filter": "^4.6.0",
             "lodash.map": "^4.6.0",
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
-        },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
-          "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
-          }
         }
       }
     },
     "libp2p-tcp": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.11.6.tgz",
-      "integrity": "sha512-ob6wIZRmwJ6X7SIZHxjQvqc3wfl/RFPXXK/C94zFi0tEraGK3bvnKdXtZEpb2kYU4fx9RUPEkHV3PJ37/HNCzA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.12.0.tgz",
+      "integrity": "sha512-zuq8bpnra1XGUK6DcsiDT0fY2QWoJQBmdQgx6Hz4L2IJTPmGBN3ww3Z8VhSqNaPmm/Dcfs7pug+pamIu3olmuQ==",
       "requires": {
+        "class-is": "^1.1.0",
         "debug": "^3.1.0",
         "interface-connection": "~0.3.2",
         "ip-address": "^5.8.9",
         "lodash.includes": "^4.3.0",
         "lodash.isfunction": "^3.0.9",
-        "mafmt": "^4.0.0",
-        "multiaddr": "^3.0.2",
+        "mafmt": "^6.0.0",
+        "multiaddr": "^4.0.0",
         "once": "^1.4.0",
         "stream-to-pull-stream": "^1.7.2"
       },
@@ -19639,53 +20037,34 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "mafmt": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-4.0.0.tgz",
-          "integrity": "sha512-zTqHhC9UUYlOkTwOXkdNqCE5U7vuz5UzlRJa4Et3ddCu/Sq36Z8F9mWCGdoqzahDcnRiGc515XjsnkAQHdH55g==",
-          "requires": {
-            "multiaddr": "^3.0.2"
-          }
-        },
-        "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "ip": "^1.1.5",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
         }
       }
     },
     "libp2p-webrtc-star": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.13.4.tgz",
-      "integrity": "sha512-ZSSWNf2RDZ9kXFEZmMfgdK+r1j6FIv+NGH5VmbRZsPSZnNnod0jvn2z7X45oq9QqTUOxzKUGkh5FIvlPVMV/yg==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.15.3.tgz",
+      "integrity": "sha512-bt6d9Oxd7/fF8zHybM4xVJKV2tl7+08kyRw+R5YkNbX5lrYT7f0NKWJUBrOrw4BnsIdEn32bDPR/yQNinKm0Vg==",
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
+        "class-is": "^1.1.0",
         "debug": "^3.1.0",
         "detect-node": "^2.0.3",
         "epimetheus": "^1.0.55",
         "hapi": "^16.6.2",
         "inert": "^4.2.1",
         "interface-connection": "~0.3.2",
-        "mafmt": "^4.0.0",
+        "mafmt": "^6.0.0",
         "minimist": "^1.2.0",
-        "multiaddr": "^3.0.2",
+        "multiaddr": "^5.0.0",
         "once": "^1.4.0",
-        "peer-id": "~0.10.6",
-        "peer-info": "~0.11.6",
-        "pull-stream": "^3.6.2",
-        "simple-peer": "^8.5.0",
-        "socket.io": "^2.0.4",
-        "socket.io-client": "^2.0.4",
-        "stream-to-pull-stream": "^1.7.2"
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1",
+        "pull-stream": "^3.6.8",
+        "simple-peer": "^9.1.2",
+        "socket.io": "^2.1.1",
+        "socket.io-client": "^2.1.1",
+        "stream-to-pull-stream": "^1.7.2",
+        "webrtcsupport": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
       },
       "dependencies": {
         "debug": {
@@ -19694,14 +20073,6 @@
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "mafmt": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-4.0.0.tgz",
-          "integrity": "sha512-zTqHhC9UUYlOkTwOXkdNqCE5U7vuz5UzlRJa4Et3ddCu/Sq36Z8F9mWCGdoqzahDcnRiGc515XjsnkAQHdH55g==",
-          "requires": {
-            "multiaddr": "^3.0.2"
           }
         },
         "minimist": {
@@ -19710,56 +20081,55 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
+          "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
           "requires": {
             "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
             "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
             "lodash.filter": "^4.6.0",
             "lodash.map": "^4.6.0",
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
-        },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
-          "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
-          }
-        },
-        "webrtcsupport": {
-          "version": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615",
-          "from": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
         }
       }
     },
     "libp2p-websocket-star": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.7.7.tgz",
-      "integrity": "sha512-unAy7kzWdUpCFVsm47B4Gk17E/XuPQo3f1cWMGTSd5AtWqsCNNTOD8dBG58DLY//o4ps511KEsNp/yp70n60AA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.8.1.tgz",
+      "integrity": "sha512-lDzL9fGWXveu6HEc6xuIEi036Bg1IQ+PliJJHxgSS9ozTkUwMT5dfvyugSWsZ7Gh4q7BYzr5cDZCNkR42GcRZw==",
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
+        "class-is": "^1.1.0",
         "data-queue": "0.0.3",
         "debug": "^3.1.0",
-        "interface-connection": "^0.3.2",
-        "libp2p-crypto": "^0.12.1",
-        "mafmt": "^4.0.0",
+        "interface-connection": "~0.3.2",
+        "libp2p-crypto": "~0.13.0",
+        "mafmt": "^6.0.0",
         "merge-recursive": "0.0.3",
-        "multiaddr": "^3.0.2",
+        "multiaddr": "^5.0.0",
         "once": "^1.4.0",
-        "peer-id": "^0.10.6",
-        "peer-info": "^0.11.6",
-        "pull-stream": "^3.6.2",
-        "socket.io-client": "^2.0.4",
-        "socket.io-pull-stream": "^0.1.4",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1",
+        "pull-stream": "^3.6.8",
+        "socket.io-client": "^2.1.1",
+        "socket.io-pull-stream": "~0.1.5",
         "uuid": "^3.2.1"
       },
       "dependencies": {
+        "asn1.js": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+          "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -19768,71 +20138,62 @@
             "ms": "2.0.0"
           }
         },
-        "mafmt": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-4.0.0.tgz",
-          "integrity": "sha512-zTqHhC9UUYlOkTwOXkdNqCE5U7vuz5UzlRJa4Et3ddCu/Sq36Z8F9mWCGdoqzahDcnRiGc515XjsnkAQHdH55g==",
+        "libp2p-crypto": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
+          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
           "requires": {
-            "multiaddr": "^3.0.2"
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.2.0",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.8",
+            "node-forge": "^0.7.5",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
         "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
+          "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
           "requires": {
             "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
             "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
             "lodash.filter": "^4.6.0",
             "lodash.map": "^4.6.0",
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
         },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
-          "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
-          }
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#master"
         }
       }
     },
     "libp2p-websockets": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.10.5.tgz",
-      "integrity": "sha512-umSnkUylBStVtsTJ2v1iWpCCUTFskbSOzUSyZ20mUwfwwPNSd+rmPkisnMRCz64l4UQ8EUs2kp7cS7kExAZODA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.0.tgz",
+      "integrity": "sha512-I4m0MNqzBOwoIneCF/5mXHGaavNf0Hoe/7NFg2WUm74o7240dZEIuNkAoLu1+OJyOPyu4RXeIBhUOS4cjBdCew==",
       "requires": {
+        "class-is": "^1.1.0",
         "interface-connection": "~0.3.2",
         "lodash.includes": "^4.3.0",
-        "mafmt": "^4.0.0",
-        "pull-ws": "^3.3.0"
-      },
-      "dependencies": {
-        "mafmt": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-4.0.0.tgz",
-          "integrity": "sha512-zTqHhC9UUYlOkTwOXkdNqCE5U7vuz5UzlRJa4Et3ddCu/Sq36Z8F9mWCGdoqzahDcnRiGc515XjsnkAQHdH55g==",
-          "requires": {
-            "multiaddr": "^3.0.2"
-          }
-        },
-        "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "ip": "^1.1.5",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        }
+        "mafmt": "^6.0.0",
+        "pull-ws": "^3.3.1"
       }
     },
     "libqp": {
@@ -20053,17 +20414,9 @@
       "requires": {
         "async": "^2.1.5",
         "find-process": "^1.0.5",
+        "fs-ext": "github:baudehlo/node-fs-ext#7c9824f3dc330e795aa13359d96252860bd3a684",
         "nodeify": "^1.0.1",
         "once": "^1.4.0"
-      },
-      "dependencies": {
-        "fs-ext": {
-          "version": "github:baudehlo/node-fs-ext#7c9824f3dc330e795aa13359d96252860bd3a684",
-          "from": "github:baudehlo/node-fs-ext#7c9824f3dc330e795aa13359d96252860bd3a684",
-          "requires": {
-            "nan": "^2.10.0"
-          }
-        }
       }
     },
     "lodash": {
@@ -20170,11 +20523,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
       "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
-    },
-    "lodash.flatmap": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
-      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4="
     },
     "lodash.flatten": {
       "version": "4.4.0",
@@ -21103,26 +21451,16 @@
       }
     },
     "memdown": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
+      "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
       "requires": {
-        "abstract-leveldown": "~2.7.1",
-        "functional-red-black-tree": "^1.0.1",
-        "immediate": "^3.2.3",
+        "abstract-leveldown": "~5.0.0",
+        "functional-red-black-tree": "~1.0.1",
+        "immediate": "~3.2.3",
         "inherits": "~2.0.1",
         "ltgt": "~2.2.0",
         "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        }
       }
     },
     "memory-fs": {
@@ -21273,10 +21611,115 @@
         "semaphore": ">=1.0.1"
       },
       "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "deferred-leveldown": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+          "requires": {
+            "abstract-leveldown": "~2.6.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "level-codec": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+        },
+        "level-errors": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+          "requires": {
+            "errno": "~0.1.1"
+          }
+        },
+        "level-iterator-stream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+          "requires": {
+            "inherits": "^2.0.1",
+            "level-errors": "^1.0.3",
+            "readable-stream": "^1.0.33",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "levelup": {
+          "version": "1.3.9",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+          "requires": {
+            "deferred-leveldown": "~1.2.1",
+            "level-codec": "~7.0.0",
+            "level-errors": "~1.0.3",
+            "level-iterator-stream": "~1.3.0",
+            "prr": "~1.0.1",
+            "semver": "~5.4.1",
+            "xtend": "~4.0.0"
+          }
+        },
+        "memdown": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+          "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+          "requires": {
+            "abstract-leveldown": "~2.7.1",
+            "functional-red-black-tree": "^1.0.1",
+            "immediate": "^3.2.3",
+            "inherits": "~2.0.1",
+            "ltgt": "~2.2.0",
+            "safe-buffer": "~5.1.1"
+          },
+          "dependencies": {
+            "abstract-leveldown": {
+              "version": "2.7.2",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+              "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+              "requires": {
+                "xtend": "~4.0.0"
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -21723,6 +22166,17 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
       "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
     },
+    "mortice": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-1.2.1.tgz",
+      "integrity": "sha512-O9O2Cx6u/AcPLLELYbCGZkcg2yvPo7zJk3+v7h8Emlne5+sg48W/shwtG5UAD+2UIuMMayC+fJ/OlZXwHfA08g==",
+      "requires": {
+        "observable-webworkers": "^1.0.0",
+        "p-queue": "^2.4.2",
+        "promise-timeout": "^1.3.0",
+        "shortid": "^2.2.8"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -21776,11 +22230,11 @@
       }
     },
     "multicast-dns": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
-      "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.0.tgz",
+      "integrity": "sha512-BqB5TtIXHo+8gN33N1CA1clsvPsAJlnc6D49SzfQA0xq75cxj15g2y9NaRdf4x2u4v1P66PBC+Wg6YgPO5Bc/g==",
       "requires": {
-        "dns-packet": "^1.3.1",
+        "dns-packet": "^4.0.0",
         "thunky": "^1.0.2"
       }
     },
@@ -25180,6 +25634,11 @@
         }
       }
     },
+    "observable-webworkers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-1.0.0.tgz",
+      "integrity": "sha512-+cECwCR8IEh8UY5nefQVLO9Cydqpk1izO+o7BABmKjXfJZyEOzBWY3ss5jbOPM6KmEa9aQExvAtTW6tVTOsNAQ=="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -25439,6 +25898,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+    },
+    "p-queue": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
     },
     "p-reduce": {
       "version": "1.0.0",
@@ -25822,38 +26286,13 @@
       "integrity": "sha1-tuDI+plJTZTgURV1gCpZpcFC8og="
     },
     "peer-book": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.5.4.tgz",
-      "integrity": "sha512-BuI/mO6OarE5839h9KLG+gSF8UPHlN8VIo6A9ZF4RlcYfOjAuOtDwgAmKIEpf3lTmVqqIkwD92KIij237yphaw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.8.0.tgz",
+      "integrity": "sha512-0An5viX2NnYeaqmwe2Vpzl03K9yxJ08mrktzkCPJyyd6rO4xz6QV2JK2Ku2vTHATP8Ag0ambxvr0QbrkT4UCYA==",
       "requires": {
         "bs58": "^4.0.1",
-        "peer-id": "^0.10.5",
-        "peer-info": "^0.11.6"
-      },
-      "dependencies": {
-        "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "ip": "^1.1.5",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "peer-info": {
-          "version": "0.11.6",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-          "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
-          "requires": {
-            "lodash.uniqby": "^4.7.0",
-            "multiaddr": "^3.0.2",
-            "peer-id": "~0.10.5"
-          }
-        }
+        "peer-id": "^0.10.7",
+        "peer-info": "^0.14.1"
       }
     },
     "peer-id": {
@@ -27406,9 +27845,9 @@
       }
     },
     "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
+      "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^1.0.2",
@@ -27569,9 +28008,10 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
     "prom-client": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
-      "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.1.1.tgz",
+      "integrity": "sha512-itUicyrq3Rko56v3ovQAMYwxEouK7lIylp26bjnlt1b/3fzn783riZnZn432I4udYmPsRgNx1F/u9RFvLyH7zA==",
+      "optional": true,
       "requires": {
         "tdigest": "^0.1.1"
       }
@@ -27607,6 +28047,11 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
+    },
+    "promise-timeout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
+      "integrity": "sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg=="
     },
     "promisify-call": {
       "version": "2.0.4",
@@ -27796,12 +28241,12 @@
       }
     },
     "pull-length-prefixed": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.0.tgz",
-      "integrity": "sha512-FkxMYPNUSFjEDEXuS6MAaKwagQAN0sonifeC+NeutQmgXy+WBdPOtPzDT1dyT69Io1wzraZ+GzXAbBGnFcjdFQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.1.tgz",
+      "integrity": "sha512-Ho0KoVKOILITGPusghadRVcUzflFHAHcv1Hvi/OkUSJLkGK2LNmVjsmIaJbWkizI//okIj2n376JyTFwCWdsYA==",
       "requires": {
         "pull-pushable": "^2.0.1",
-        "pull-reader": "^1.2.9",
+        "pull-reader": "^1.3.0",
         "safe-buffer": "^5.0.1",
         "varint": "^5.0.0"
       }
@@ -29007,6 +29452,11 @@
         "remark-slug": "^5.0.0"
       }
     },
+    "remedial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg=="
+    },
     "remote-origin-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.4.0.tgz",
@@ -29782,16 +30232,16 @@
       }
     },
     "service-worker-gateway": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/service-worker-gateway/-/service-worker-gateway-0.1.3.tgz",
-      "integrity": "sha512-sbJGOT+W9f5jPjq8KTFeZM6z6lKyxAyVah++N7T3imHatq73e/MSQZH9kvR6agAM5zZXyYcAr21GyZ7VxwVvXg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/service-worker-gateway/-/service-worker-gateway-0.1.4.tgz",
+      "integrity": "sha512-dAMzR/fzUB/f8WO+eQvAmHbicmRF2aJAM9T1arfliMh/9PN2Y7Y0LVtDarugTp3Q91wj/jbbppomOn+pCpe9Yg==",
       "requires": {
         "async": "^2.6.0",
         "cids": "^0.5.3",
         "debug": "^3.1.0",
         "file-type": "^8.0.0",
         "filesize": "^3.6.1",
-        "ipfs": "^0.28.2",
+        "ipfs": "^0.30.1",
         "ipfs-http-response": "^0.1.2",
         "ipfs-postmsg-proxy": "^2.3.0",
         "ipfs-unixfs": "^0.1.14",
@@ -30020,9 +30470,9 @@
       }
     },
     "simple-peer": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-8.5.0.tgz",
-      "integrity": "sha512-L901ld7sqQv7c8ehThEZGIDqgBrTC1iJLlcqFlqtH3YhUb+S8uBjdQpzaJGth+NkSoWNJSsXjNyWbzaM99cMQg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.1.2.tgz",
+      "integrity": "sha512-MUWWno5o5cvISKOH4pYQ18PQJLpDaNWoKUbrPPKuspCLCkkh+zhtuQyTE8h2U2Ags+/OUN5wnUe92+9B8/Sm2Q==",
       "requires": {
         "debug": "^3.1.0",
         "get-browser-rtc": "^1.0.0",
@@ -32017,6 +32467,11 @@
       "dev": true,
       "optional": true
     },
+    "tiny-each-async": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
+      "integrity": "sha1-jru/1tYpXxNwAD+7NxYq/loKUdE="
+    },
     "tiny-emitter": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
@@ -32369,9 +32824,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
-      "integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "typeforce": {
       "version": "1.12.0",
@@ -34582,6 +35040,10 @@
         }
       }
     },
+    "webrtcsupport": {
+      "version": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615",
+      "from": "github:ipfs/webrtcsupport"
+    },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
@@ -34878,6 +35340,11 @@
       "requires": {
         "camelcase": "^4.1.0"
       }
+    },
+    "yargs-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-promise/-/yargs-promise-1.1.0.tgz",
+      "integrity": "sha1-l+u1GY33NLs7EXRRM65bUBsWqx8="
     },
     "yeast": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-scroll-to-component": "^1.0.2",
     "react-slick": "~0.23.1",
     "recompose": "~0.27.1",
-    "service-worker-gateway": "~0.1.3",
+    "service-worker-gateway": "~0.1.4",
     "slick-carousel": "^1.8.1"
   },
   "keywords": [


### PR DESCRIPTION
It turns out this was an issue with Gatsby.
Basically, Gatsby was changing `resolve.modulesDirectories` which was causing the root `big.js` to be required instead of the one inside `libp2p-switch`.

See https://github.com/webpack/webpack/issues/6538#issuecomment-367324775 for more information.

Fixes #39 