### PR TITLE
Fix/content shifting

### DIFF
--- a/src/shared/components/carousel/index.js
+++ b/src/shared/components/carousel/index.js
@@ -47,7 +47,9 @@ class Carousel extends Component {
             desc={ translationsList[translationIndex].desc }
             link={ item.link }
             image={ item.image }
-            index={ index } />
+            index={ index }
+            iconRatio={ item.iconRatio }
+            containerMaxWidth={ item.containerMaxWidth }/>
         )
       })
     } else if (modifier === 'videos') {

--- a/src/shared/components/carousel/index.js
+++ b/src/shared/components/carousel/index.js
@@ -49,7 +49,7 @@ class Carousel extends Component {
             image={ item.image }
             index={ index }
             iconRatio={ item.iconRatio }
-            containerMaxWidth={ item.containerMaxWidth }/>
+            iconMaxWidth={ item.iconMaxWidth }/>
         )
       })
     } else if (modifier === 'videos') {

--- a/src/shared/components/carousel/projects-item/index.js
+++ b/src/shared/components/carousel/projects-item/index.js
@@ -5,18 +5,28 @@ import ReactMarkdown from 'react-markdown'
 import Button from 'shared/components/button'
 import styles from './index.module.css'
 
-const ProjectItem = ({ icon, desc, link, image, index }) => (
+const ProjectItem = ({ icon, desc, link, image, index, iconRatio, containerMaxWidth }) => (
   <div className={ styles.container }>
     <div className={ styles.leftContainer }>
       <div className={ styles.topContainer }>
-        { icon && <div className={ styles.logo }>{ icon }</div> }
+        { icon &&
+          <div className={ styles.logoWrapper } style={ { maxWidth: containerMaxWidth } }>
+            <div className={ styles.logoContainer } style={ { paddingBottom: iconRatio } }>
+              <div className={ styles.logo }>{ icon }</div>
+            </div>
+          </div>
+        }
         <ReactMarkdown className={ styles.desc } source={ desc } />
       </div>
       <div className={ styles.bottomContainer }>
         <Button translationId="buttonLearnMore" href={ link } />
       </div>
     </div>
-    <div className={ styles.rightContainer }><img src={ image } alt="" /></div>
+    <div className={ styles.rightContainer }>
+      <div className={ styles.imageWrapper }>
+        <img src={ image } alt="" />
+      </div>
+    </div>
   </div>
 )
 
@@ -25,7 +35,9 @@ ProjectItem.propTypes = {
   desc: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
   image: PropTypes.string.isRequired,
-  index: PropTypes.number.isRequired
+  index: PropTypes.number.isRequired,
+  iconRatio: PropTypes.string.isRequired,
+  containerMaxWidth: PropTypes.string
 }
 
 export default ProjectItem

--- a/src/shared/components/carousel/projects-item/index.js
+++ b/src/shared/components/carousel/projects-item/index.js
@@ -5,16 +5,14 @@ import ReactMarkdown from 'react-markdown'
 import Button from 'shared/components/button'
 import styles from './index.module.css'
 
-const ProjectItem = ({ icon, desc, link, image, index, iconRatio, containerMaxWidth }) => (
+const ProjectItem = ({ icon, desc, link, image, index, iconRatio, iconMaxWidth }) => (
   <div className={ styles.container }>
     <div className={ styles.leftContainer }>
       <div className={ styles.topContainer }>
         { icon &&
-          <div className={ styles.logoWrapper } style={ { maxWidth: containerMaxWidth } }>
-            <div className={ styles.logoContainer } style={ { paddingBottom: iconRatio } }>
-              <div className={ styles.logo }>{ icon }</div>
+            <div className={ styles.logoContainer } style={ { maxWidth: iconMaxWidth } }>
+              <div className={ styles.logo } style={ { paddingBottom: iconRatio } }>{ icon }</div>
             </div>
-          </div>
         }
         <ReactMarkdown className={ styles.desc } source={ desc } />
       </div>
@@ -24,7 +22,7 @@ const ProjectItem = ({ icon, desc, link, image, index, iconRatio, containerMaxWi
     </div>
     <div className={ styles.rightContainer }>
       <div className={ styles.imageWrapper }>
-        <img src={ image } alt="" />
+        <img src={ image } alt="Project Preview" />
       </div>
     </div>
   </div>
@@ -37,7 +35,7 @@ ProjectItem.propTypes = {
   image: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
   iconRatio: PropTypes.string.isRequired,
-  containerMaxWidth: PropTypes.string
+  iconMaxWidth: PropTypes.string
 }
 
 export default ProjectItem

--- a/src/shared/components/carousel/projects-item/index.module.css
+++ b/src/shared/components/carousel/projects-item/index.module.css
@@ -20,15 +20,15 @@
       flex-direction: column;
       align-items: flex-start;
 
-      & .logoWrapper {
+      & .logoContainer {
         width: 70%;
         margin-bottom: 15px;
 
-        & .logoContainer {
+        & .logo {
           position: relative;
           width: 100%;
 
-          & .logo {
+          & > * {
             position: absolute;
             top: 0;
             left: 0;
@@ -60,7 +60,7 @@
       padding-bottom: 62.5%;
       box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.3);
 
-      & img {
+      & > * {
         position: absolute;
         top: 0;
         left: 0;

--- a/src/shared/components/carousel/projects-item/index.module.css
+++ b/src/shared/components/carousel/projects-item/index.module.css
@@ -20,9 +20,21 @@
       flex-direction: column;
       align-items: flex-start;
 
-      & .logo {
+      & .logoWrapper {
         width: 70%;
         margin-bottom: 15px;
+
+        & .logoContainer {
+          position: relative;
+          width: 100%;
+
+          & .logo {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+          }
+        }
       }
 
       & .desc {
@@ -42,9 +54,18 @@
     max-width: 70%;
     flex: 1;
 
-    & img {
+    & .imageWrapper {
+      position: relative;
       width: 100%;
+      padding-bottom: 62.5%;
       box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.3);
+
+      & img {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+      }
     }
   }
 }

--- a/src/shared/components/gateway-section/index.js
+++ b/src/shared/components/gateway-section/index.js
@@ -49,6 +49,7 @@ class GatewaySection extends Component {
     const { isActive, inView, incompatible, inProgress, isMessageVisible, renderAnimation } = this.state
     const { messages } = this.props.intl
     const contentClasses = classNames(styles.content, {
+      [styles.notRendering]: !renderAnimation,
       [styles.active]: isActive
     })
 

--- a/src/shared/components/gateway-section/index.js
+++ b/src/shared/components/gateway-section/index.js
@@ -20,7 +20,7 @@ class GatewaySection extends Component {
     incompatible: false,
     inProgress: false,
     isMessageVisible: true,
-    renderAnimation: false
+    renderGateway: false
   }
 
   componentDidMount () {
@@ -30,7 +30,7 @@ class GatewaySection extends Component {
       })
       .catch((err) => console.error(err))
 
-    this.setState({ renderAnimation: true, incompatible: !isCompatible() })
+    this.setState({ renderGateway: true, incompatible: !isCompatible() })
   }
 
   componentWillUnmount () {
@@ -46,10 +46,9 @@ class GatewaySection extends Component {
   }
 
   render () {
-    const { isActive, inView, incompatible, inProgress, isMessageVisible, renderAnimation } = this.state
+    const { isActive, inView, incompatible, inProgress, isMessageVisible, renderGateway } = this.state
     const { messages } = this.props.intl
     const contentClasses = classNames(styles.content, {
-      [styles.notRendering]: !renderAnimation,
       [styles.active]: isActive
     })
 
@@ -60,16 +59,18 @@ class GatewaySection extends Component {
           <span className={ styles.sectionDescription }>
             <p>{ messages.serviceWorker.sectionDesc }</p>
           </span>
-          { renderAnimation && (
-            <Observer onChange={ this.handleObserverChange } >
-              <GatewaySvgAnimation
-                isActive={ isActive }
-                inView={ inView }
-                isMessageVisible={ isMessageVisible }
-                onMessageCloseClick={ this.handleCloseClick }
-              />
-            </Observer>
-          ) }
+          <div className={ styles.gatewayContainer }>
+            { renderGateway && (
+              <Observer onChange={ this.handleObserverChange }>
+                <GatewaySvgAnimation
+                  isActive={ isActive }
+                  inView={ inView }
+                  isMessageVisible={ isMessageVisible }
+                  onMessageCloseClick={ this.handleCloseClick }
+                />
+              </Observer>
+            ) }
+          </div>
           <ToggleButton
             isActive={ isActive }
             onClick={ this.handleToggleClick }

--- a/src/shared/components/gateway-section/index.module.css
+++ b/src/shared/components/gateway-section/index.module.css
@@ -17,6 +17,10 @@
     max-width: var(--max-container-width);
     padding: 10% 0 0 0;
 
+    &.notRendering {
+      padding: 10% 0;
+    }
+
     &.active {
       & .message {
         opacity: 1;

--- a/src/shared/components/gateway-section/index.module.css
+++ b/src/shared/components/gateway-section/index.module.css
@@ -17,10 +17,6 @@
     max-width: var(--max-container-width);
     padding: 10% 0 0 0;
 
-    &.notRendering {
-      padding: 10% 0;
-    }
-
     &.active {
       & .message {
         opacity: 1;
@@ -57,6 +53,19 @@
         font-weight: var(--typography-text-weight);
         text-align: center;
         line-height: var(--line-height-medium);
+      }
+    }
+
+    & .gatewayContainer {
+      position: relative;
+      width: 100%;
+      padding-bottom: 47%;
+
+      & > * {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
       }
     }
   }

--- a/src/shared/components/hero-section/index.js
+++ b/src/shared/components/hero-section/index.js
@@ -54,7 +54,11 @@ class Hero extends Component {
             </div>
           </div>
           <div className={ styles.content }>
-            <Svg svg={ cubeSvg } className={ styles.cube } />
+            <div className={ styles.cubeWrapper }>
+              <div className={ styles.cubeContainer }>
+                <Svg svg={ cubeSvg } className={ styles.cube } />
+              </div>
+            </div>
             <h1>{ messages.hero.welcomeMessage }</h1>
             <ReactMarkdown className={ styles.textDesc } source={ messages.hero.textDescription } />
             <div className={ infoContainerClasses }>

--- a/src/shared/components/hero-section/index.module.css
+++ b/src/shared/components/hero-section/index.module.css
@@ -104,6 +104,7 @@
     }
 
     & h1 {
+      min-height: 48px;
       font-weight: var(--typography-text-weight-semibold);
       text-transform: none;
       text-align: center;
@@ -112,6 +113,7 @@
 
     & .textDesc {
       max-width: 70%;
+      min-height: 54px;
 
       & p {
         font-size: var(--typography-text-size);
@@ -123,6 +125,7 @@
 
     & .infoContainer {
       width: 100%;
+      min-height: 16px;
       margin-top: 2%;
       opacity: 0;
       color: var(--color-light-blue);

--- a/src/shared/components/hero-section/index.module.css
+++ b/src/shared/components/hero-section/index.module.css
@@ -85,10 +85,22 @@
     justify-content: center;
     align-items: center;
 
-    & .cube {
+    & .cubeWrapper {
       width: 29%;
-      height: auto;
       margin: 0 0 1.5% 4%;
+
+      & .cubeContainer {
+        position: relative;
+        width: 100%;
+        padding-bottom: 96.8%;
+
+        & .cube {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+        }
+      }
     }
 
     & h1 {
@@ -138,7 +150,7 @@
 }
 
 @media (--layout-lte-large) {
-  .container .content .cube {
+  .container .content .cubeWrapper {
     width: 26%;
   }
 }
@@ -165,7 +177,7 @@
       width: var(--container-width-mobile);
       padding: 30% 0 50px;
 
-      & .cube {
+      & .cubeWrapper {
         width: 75%;
         max-width: 300px;
         margin: 0 0 10% 10%;

--- a/src/shared/components/locales-bar/index.module.css
+++ b/src/shared/components/locales-bar/index.module.css
@@ -15,7 +15,6 @@
     border-right: 1px solid var(--color-blue-dark-shade);
     color: var(--color-blue-dark-shade);
     text-decoration: none;
-    transition: var(--transition-default-duration) ease;
 
     &:last-child {
       border-right: 0;

--- a/src/shared/components/locales-dropdown/index.module.css
+++ b/src/shared/components/locales-dropdown/index.module.css
@@ -19,7 +19,7 @@
     background: transparent;
     color: var(--color-white);
     cursor: pointer;
-    transition: var(--transition-default-duration) ease;
+    transition: color var(--transition-default-duration) ease;
 
     &:hover {
       color: var(--color-yellow);
@@ -41,7 +41,10 @@
       border-top: 1px solid var(--color-white);
       border-right: 1px solid var(--color-white);
       pointer-events: none;
-      transition: var(--transition-default-duration) ease;
+      transition:
+        transform var(--transition-default-duration) ease,
+        margin-top var(--transition-default-duration) ease,
+        margin-bottom var(--transition-default-duration) ease;
     }
 
     & .arrowBottom {

--- a/src/shared/components/nav-bar/desktop/index.js
+++ b/src/shared/components/nav-bar/desktop/index.js
@@ -31,9 +31,11 @@ class DesktopNavBar extends Component {
           <Link href="https://github.com/ipfs/js-ipfs">
             { messages.navBar.item4 }
           </Link>
-          <a className="github-button" href="https://github.com/ipfs/js-ipfs" data-show-count="true" aria-label="Star ipfs/js-ipfs on GitHub">
+          <div className={ styles.starContainer }>
+            <a className="github-button" href="https://github.com/ipfs/js-ipfs" data-show-count="true" aria-label="Star ipfs/js-ipfs on GitHub">
               Star
-          </a>
+            </a>
+          </div>
         </div>
       </div>
     )

--- a/src/shared/components/nav-bar/desktop/index.module.css
+++ b/src/shared/components/nav-bar/desktop/index.module.css
@@ -11,12 +11,14 @@
   width: 100%;
   height: var(--nav-bar-desktop-height);
   padding: 20px 0;
+  display: flex;
   background: var(--color-menu-dark-blue);
   font-size: var(--typography-menu-text-size);
   text-align: center;
   transition: var(--transition-default-duration) ease;
 
   & .navBarMenu {
+    width: 100%;
     display: flex;
     justify-content: center;
 
@@ -40,8 +42,15 @@
       }
     }
 
-    & > span {
-      margin-top: 2px;
+    & > .starContainer {
+      min-width: 97px;
+      min-height: 24px;
+      display: flex;
+      align-items: center;
+
+      & > span {
+        margin-top: 2px;
+      }
     }
   }
 }

--- a/src/shared/components/nav-bar/desktop/index.module.css
+++ b/src/shared/components/nav-bar/desktop/index.module.css
@@ -15,7 +15,6 @@
   background: var(--color-menu-dark-blue);
   font-size: var(--typography-menu-text-size);
   text-align: center;
-  transition: var(--transition-default-duration) ease;
 
   & .navBarMenu {
     width: 100%;
@@ -31,7 +30,7 @@
       text-decoration: none;
       text-transform: uppercase;
       cursor: pointer;
-      transition: var(--transition-default-duration) ease;
+      transition: color var(--transition-default-duration) ease;
 
       &:nth-child(4) {
         margin-right: 15px;

--- a/src/shared/components/nav-bar/mobile/index.module.css
+++ b/src/shared/components/nav-bar/mobile/index.module.css
@@ -35,7 +35,9 @@
         height: 2px;
         margin: 5px 0;
         background: var(--color-white);
-        transition: var(--transition-duration-half);
+        transition:
+          transform var(--transition-duration-half) ease,
+          opacity var(--transition-duration-half) ease;
       }
 
       &.hamburgerOpened {

--- a/src/shared/data/what-are-people-building/index.js
+++ b/src/shared/data/what-are-people-building/index.js
@@ -18,7 +18,7 @@ import peerpadImage from './images/peerpad.jpg'
   These 2 props are used to prevent page reflow:
     - iconRatio: (height / width) * 100. We are calculating the icon ratio before it is loaded and set a paddingBottom to its wrapper div
     with this percentage to work as a placeholder while the logo is beeing loaded.
-    - containerMaxWidth: When logos are squared their ratio would be almost 100%, that would make them too big. To circumvent that we set
+    - iconMaxWidth: When icons are squared their ratio would be almost 100%, that would make them too big. To circumvent that we set
     the container max-width to make the icon "scale down" keeping its ratio.
 */
 
@@ -41,7 +41,7 @@ const projects = [
     translationListIndex: 2,
     icon: <Svg svg={ dwebArchiveSvg } />,
     iconRatio: '97.1%',
-    containerMaxWidth: '90px',
+    iconMaxWidth: '90px',
     image: dwebArchiveImage,
     link: 'https://dweb.archive.org'
   },

--- a/src/shared/data/what-are-people-building/index.js
+++ b/src/shared/data/what-are-people-building/index.js
@@ -14,40 +14,55 @@ import paratiiImage from './images/paratii.jpg'
 import peerpadSvg from './images/peerpad-logo.svg'
 import peerpadImage from './images/peerpad.jpg'
 
+/*
+  These 2 props are used to prevent page reflow:
+    - iconRatio: (height / width) * 100. We are calculating the icon ratio before it is loaded and set a paddingBottom to its wrapper div
+    with this percentage to work as a placeholder while the logo is beeing loaded.
+    - containerMaxWidth: When logos are squared their ratio would be almost 100%, that would make them too big. To circumvent that we set
+    the container max-width to make the icon "scale down" keeping its ratio.
+*/
+
 const projects = [
   {
     translationListIndex: 0,
     icon: <Svg svg={ paratiiSvg } />,
+    iconRatio: '29.2%',
     image: paratiiImage,
     link: 'https://paratii.video'
   },
   {
     translationListIndex: 1,
     icon: <Svg svg={ filenationSvg } />,
+    iconRatio: '29.3%',
     image: filenationImage,
     link: 'https://filenation.io'
   },
   {
     translationListIndex: 2,
-    icon: <Svg svg={ dwebArchiveSvg } style={ { maxWidth: 90 } }/>,
+    icon: <Svg svg={ dwebArchiveSvg } />,
+    iconRatio: '97.1%',
+    containerMaxWidth: '90px',
     image: dwebArchiveImage,
     link: 'https://dweb.archive.org'
   },
   {
     translationListIndex: 3,
     icon: <Svg svg={ peerpadSvg } />,
+    iconRatio: '32.4%',
     image: peerpadImage,
     link: 'https://peerpad.net'
   },
   {
     translationListIndex: 4,
     icon: <Svg svg={ companionSvg } />,
+    iconRatio: '45%',
     image: companionImage,
     link: 'https://github.com/ipfs-shipyard/ipfs-companion'
   },
   {
     translationListIndex: 5,
     icon: <Svg svg={ orbitchatSvg } />,
+    iconRatio: '36.6%',
     image: orbitchatImage,
     link: 'https://orbit.chat'
   }

--- a/src/shared/styles/imports/variables.css
+++ b/src/shared/styles/imports/variables.css
@@ -37,8 +37,8 @@
    ========================================================================== */
 
 :root {
-  --typography-display-font: "Montserrat", sans-serif;
-  --typography-text-font: "Montserrat", sans-serif;
+  --typography-display-font: "Montserrat", Verdana, sans-serif;
+  --typography-text-font: "Montserrat", Tahoma, Verdana, sans-serif;
   --typography-roboto-text-font: "Roboto", sans-serif;
   --typography-text-size-large: 18px;
   --typography-text-size: 15px;


### PR DESCRIPTION
This PR fixes content shifting while some data is being loaded in some sections:

- nav-bar
- hero section
  - cube image
  - title
  - description
  - IPFS pkg info
- 'What people are building with it' section
  - carousel image
  - carousel logo
- 'Service worker gateway' section
  - `padding-bottom` matching `padding-top` when `renderAnimation` is false

It closes #154.