### PR TITLE
fix: bundle ipfs module

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -15,6 +15,9 @@ const { defaultLocale, availableLocales } = require('./intl/config')
 module.exports.onCreateWebpackConfig = ({ actions, getConfig, stage }) => {
   let config = getConfig()
 
+  // Name for non-entry chunk files. E.g. dynamic imports
+  config.output.chunkFilename = '[name].[chunkhash].js'
+
   // Fix Gatsby setting `resolve.modules` to `path.resolve(__dirname, "node_modules")`
   // which causes module resolution errors when the npm tree is deduped
   // See both https://github.com/webpack/webpack/issues/6538#issuecomment-367324775 and

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,17 +39,17 @@
       }
     },
     "@babel/core": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
-      "integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.5.tgz",
+      "integrity": "sha512-vOyH020C56tQvte++i+rX2yokZcRfbv/kKcw+/BCRw/cK6dvsr47aCzm8oC1XHwMSEWbqrZKzZRLzLnq6SFMsg==",
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/generator": "7.1.3",
-        "@babel/helpers": "7.1.2",
-        "@babel/parser": "7.1.3",
+        "@babel/generator": "7.1.5",
+        "@babel/helpers": "7.1.5",
+        "@babel/parser": "7.1.5",
         "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3",
+        "@babel/traverse": "7.1.5",
+        "@babel/types": "7.1.5",
         "convert-source-map": "1.6.0",
         "debug": "3.1.0",
         "json5": "0.5.1",
@@ -60,12 +60,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
-      "integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.5.tgz",
+      "integrity": "sha512-IO31r62xfMI+wBJVmgx0JR9ZOHty8HkoYpQAjRWUGG9vykBTlGHdArZ8zoFtpUu2gs17K7qTl/TtPpiSi6t+MA==",
       "requires": {
-        "@babel/types": "7.1.3",
-        "jsesc": "2.5.1",
+        "@babel/types": "7.1.5",
+        "jsesc": "2.5.2",
         "lodash": "4.17.11",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
@@ -76,7 +76,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -85,7 +85,7 @@
       "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
       "requires": {
         "@babel/helper-explode-assignable-expression": "7.1.0",
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-builder-react-jsx": {
@@ -93,7 +93,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
       "integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
       "requires": {
-        "@babel/types": "7.1.3",
+        "@babel/types": "7.1.5",
         "esutils": "2.0.2"
       }
     },
@@ -103,8 +103,8 @@
       "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
       "requires": {
         "@babel/helper-hoist-variables": "7.0.0",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.5",
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-define-map": {
@@ -113,7 +113,7 @@
       "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
       "requires": {
         "@babel/helper-function-name": "7.1.0",
-        "@babel/types": "7.1.3",
+        "@babel/types": "7.1.5",
         "lodash": "4.17.11"
       }
     },
@@ -122,8 +122,8 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
       "requires": {
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.5",
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-function-name": {
@@ -133,7 +133,7 @@
       "requires": {
         "@babel/helper-get-function-arity": "7.0.0",
         "@babel/template": "7.1.2",
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -141,7 +141,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -149,7 +149,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
       "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -157,7 +157,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-module-imports": {
@@ -165,7 +165,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-module-transforms": {
@@ -177,7 +177,7 @@
         "@babel/helper-simple-access": "7.1.0",
         "@babel/helper-split-export-declaration": "7.0.0",
         "@babel/template": "7.1.2",
-        "@babel/types": "7.1.3",
+        "@babel/types": "7.1.5",
         "lodash": "4.17.11"
       }
     },
@@ -186,7 +186,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -210,8 +210,8 @@
         "@babel/helper-annotate-as-pure": "7.0.0",
         "@babel/helper-wrap-function": "7.1.0",
         "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.5",
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-replace-supers": {
@@ -221,8 +221,8 @@
       "requires": {
         "@babel/helper-member-expression-to-functions": "7.0.0",
         "@babel/helper-optimise-call-expression": "7.0.0",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.5",
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-simple-access": {
@@ -231,7 +231,7 @@
       "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
       "requires": {
         "@babel/template": "7.1.2",
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -239,7 +239,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helper-wrap-function": {
@@ -249,18 +249,18 @@
       "requires": {
         "@babel/helper-function-name": "7.1.0",
         "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.5",
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/helpers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
-      "integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.5.tgz",
+      "integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
       "requires": {
         "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.5",
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/highlight": {
@@ -274,9 +274,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
-      "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w=="
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.5.tgz",
+      "integrity": "sha512-WXKf5K5HT6X0kKiCOezJZFljsfxKV1FpU8Tf1A7ZpGvyd/Q4hlrJm2EwoH2onaUq3O4tLDp+4gk0hHPsMyxmOg=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.1.0",
@@ -670,9 +670,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
-      "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.1.5.tgz",
+      "integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "lodash": "4.17.11"
@@ -952,9 +952,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
-      "integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.5.tgz",
+      "integrity": "sha512-pQ+2o0YyCp98XG0ODOHJd9z4GsSoV5jicSedRwCrU8uiqcJahwQiOq0asSZEb/m/lwyu6X5INvH/DSiwnQKncw==",
       "requires": {
         "@babel/helper-module-imports": "7.0.0",
         "@babel/helper-plugin-utils": "7.0.0",
@@ -969,7 +969,7 @@
         "@babel/plugin-transform-arrow-functions": "7.0.0",
         "@babel/plugin-transform-async-to-generator": "7.1.0",
         "@babel/plugin-transform-block-scoped-functions": "7.0.0",
-        "@babel/plugin-transform-block-scoping": "7.0.0",
+        "@babel/plugin-transform-block-scoping": "7.1.5",
         "@babel/plugin-transform-classes": "7.1.0",
         "@babel/plugin-transform-computed-properties": "7.0.0",
         "@babel/plugin-transform-destructuring": "7.1.3",
@@ -1004,8 +1004,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
           "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83",
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84",
             "node-releases": "1.0.3"
           }
         }
@@ -1055,9 +1055,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
-      "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
+      "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
       "requires": {
         "regenerator-runtime": "0.12.1"
       },
@@ -1075,30 +1075,30 @@
       "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/parser": "7.1.3",
-        "@babel/types": "7.1.3"
+        "@babel/parser": "7.1.5",
+        "@babel/types": "7.1.5"
       }
     },
     "@babel/traverse": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
-      "integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.5.tgz",
+      "integrity": "sha512-eU6XokWypl0MVJo+MTSPUtlfPePkrqsF26O+l1qFGlCKWwmiYAYy2Sy44Qw8m2u/LbPCsxYt90rghmqhYMGpPA==",
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/generator": "7.1.3",
+        "@babel/generator": "7.1.5",
         "@babel/helper-function-name": "7.1.0",
         "@babel/helper-split-export-declaration": "7.0.0",
-        "@babel/parser": "7.1.3",
-        "@babel/types": "7.1.3",
+        "@babel/parser": "7.1.5",
+        "@babel/types": "7.1.5",
         "debug": "3.1.0",
         "globals": "11.8.0",
         "lodash": "4.17.11"
       }
     },
     "@babel/types": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
-      "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.5.tgz",
+      "integrity": "sha512-sJeqa/d9eM/bax8Ivg+fXF7FpN3E/ZmTrWbkk6r+g7biVYfALMnLin4dKijsaqEhpd2xvOGfQTkQkD31YCVV4A==",
       "requires": {
         "esutils": "2.0.2",
         "lodash": "4.17.11",
@@ -1395,18 +1395,18 @@
       "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ=="
     },
     "@types/reach__router": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.2.1.tgz",
-      "integrity": "sha512-gzQuJDszKU1uyAgyJtR+vkrK9F6w6GfiR1uWn0rMYzuou/3wO5388m5ymUQDtTTjUcSSID/cMvQiCE8N/eOWRQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.2.2.tgz",
+      "integrity": "sha512-ktF+0xWesuojMlU8UR+7O9qU9Ff76gO/0Lc+QXQYpTDK0qz4a0l/fJYOLmMJKVY7LKGLBmB3TBs7Fvg4nibQsA==",
       "requires": {
         "@types/history": "4.7.2",
-        "@types/react": "16.4.18"
+        "@types/react": "16.7.1"
       }
     },
     "@types/react": {
-      "version": "16.4.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.18.tgz",
-      "integrity": "sha512-eFzJKEg6pdeaukVLVZ8Xb79CTl/ysX+ExmOfAAqcFlCCK5TgFDD9kWR0S18sglQ3EmM8U+80enjUqbfnUyqpdA==",
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.7.1.tgz",
+      "integrity": "sha512-kxde2oP2JvHiEXiAfb8WkL+8Aa9txDRD7L8zb3BipMNRoBbcr32xy/kfpbxmWMus71yXgJDqBgLmWil6UXdLzQ==",
       "requires": {
         "@types/prop-types": "15.5.6",
         "csstype": "2.5.7"
@@ -1739,7 +1739,7 @@
         "execa": "1.0.0",
         "filesize": "3.6.1",
         "findup-sync": "2.0.0",
-        "fs-extra": "7.0.0",
+        "fs-extra": "7.0.1",
         "gh-pages": "2.0.1",
         "git-validate": "2.2.4",
         "glob": "7.1.3",
@@ -1778,7 +1778,7 @@
         "transform-loader": "0.2.4",
         "uglify-es": "3.3.9",
         "update-notifier": "2.5.0",
-        "webpack": "4.25.0",
+        "webpack": "4.25.1",
         "webpack-bundle-analyzer": "3.0.3",
         "webpack-cli": "3.1.2",
         "webpack-merge": "4.1.4",
@@ -1786,6 +1786,86 @@
         "yargs-parser": "11.0.0"
       },
       "dependencies": {
+        "@babel/core": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
+          "integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0",
+            "@babel/generator": "7.1.5",
+            "@babel/helpers": "7.1.5",
+            "@babel/parser": "7.1.5",
+            "@babel/template": "7.1.2",
+            "@babel/traverse": "7.1.5",
+            "@babel/types": "7.1.5",
+            "convert-source-map": "1.6.0",
+            "debug": "3.1.0",
+            "json5": "0.5.1",
+            "lodash": "4.17.11",
+            "resolve": "1.8.1",
+            "semver": "5.6.0",
+            "source-map": "0.5.7"
+          }
+        },
+        "@babel/preset-env": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
+          "integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "7.0.0",
+            "@babel/helper-plugin-utils": "7.0.0",
+            "@babel/plugin-proposal-async-generator-functions": "7.1.0",
+            "@babel/plugin-proposal-json-strings": "7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "7.0.0",
+            "@babel/plugin-proposal-unicode-property-regex": "7.0.0",
+            "@babel/plugin-syntax-async-generators": "7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "7.0.0",
+            "@babel/plugin-syntax-optional-catch-binding": "7.0.0",
+            "@babel/plugin-transform-arrow-functions": "7.0.0",
+            "@babel/plugin-transform-async-to-generator": "7.1.0",
+            "@babel/plugin-transform-block-scoped-functions": "7.0.0",
+            "@babel/plugin-transform-block-scoping": "7.1.5",
+            "@babel/plugin-transform-classes": "7.1.0",
+            "@babel/plugin-transform-computed-properties": "7.0.0",
+            "@babel/plugin-transform-destructuring": "7.1.3",
+            "@babel/plugin-transform-dotall-regex": "7.0.0",
+            "@babel/plugin-transform-duplicate-keys": "7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "7.1.0",
+            "@babel/plugin-transform-for-of": "7.0.0",
+            "@babel/plugin-transform-function-name": "7.1.0",
+            "@babel/plugin-transform-literals": "7.0.0",
+            "@babel/plugin-transform-modules-amd": "7.1.0",
+            "@babel/plugin-transform-modules-commonjs": "7.1.0",
+            "@babel/plugin-transform-modules-systemjs": "7.1.3",
+            "@babel/plugin-transform-modules-umd": "7.1.0",
+            "@babel/plugin-transform-new-target": "7.0.0",
+            "@babel/plugin-transform-object-super": "7.1.0",
+            "@babel/plugin-transform-parameters": "7.1.0",
+            "@babel/plugin-transform-regenerator": "7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "7.0.0",
+            "@babel/plugin-transform-spread": "7.0.0",
+            "@babel/plugin-transform-sticky-regex": "7.0.0",
+            "@babel/plugin-transform-template-literals": "7.0.0",
+            "@babel/plugin-transform-typeof-symbol": "7.0.0",
+            "@babel/plugin-transform-unicode-regex": "7.0.0",
+            "browserslist": "4.3.4",
+            "invariant": "2.2.4",
+            "js-levenshtein": "1.1.4",
+            "semver": "5.6.0"
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
+          "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "0.12.1"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1799,6 +1879,17 @@
           "dev": true,
           "requires": {
             "lodash": "4.17.11"
+          }
+        },
+        "browserslist": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
+          "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84",
+            "node-releases": "1.0.3"
           }
         },
         "decamelize": {
@@ -1902,9 +1993,9 @@
           }
         },
         "fs-extra": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-          "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.15",
@@ -1921,10 +2012,28 @@
             "pump": "3.0.0"
           }
         },
+        "gzip-size": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
+          "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
+          "dev": true,
+          "requires": {
+            "duplexer": "0.1.1",
+            "pify": "3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
         "hoek": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.1.tgz",
-          "integrity": "sha512-3PvUwBerLNVJiIVQdpkWF9F/M0ekgb2NPJWOhsE28RXSQPsY42YSnaJ8d1kZjcAz58TZ/Fk9Tw64xJsENFlJNw==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.2.tgz",
+          "integrity": "sha512-0RGPLkyxpsMJVj/iOCaJaIWFEch988eUicJJpRiQ+Or1CMvBXcoZPlSx9FhreDWw4hxMYy8xgTEdlsYQDTnxWA==",
           "dev": true
         },
         "invert-kv": {
@@ -1939,7 +2048,7 @@
           "integrity": "sha512-KUXRcinDUMMbtlOk7YLGHQvG73dLyf8bmgE+6sBTkdJbZpeGVGAlPXEHLiQBV7KinD/VLD5OA0EUgoTTfbRAJQ==",
           "dev": true,
           "requires": {
-            "hoek": "6.0.1",
+            "hoek": "6.0.2",
             "isemail": "3.2.0",
             "topo": "3.0.3"
           }
@@ -2135,6 +2244,12 @@
             "util-deprecate": "1.0.2"
           }
         },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
+        },
         "stream-http": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.0.0.tgz",
@@ -2162,7 +2277,36 @@
           "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
           "dev": true,
           "requires": {
-            "hoek": "6.0.1"
+            "hoek": "6.0.2"
+          }
+        },
+        "webpack-bundle-analyzer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.3.tgz",
+          "integrity": "sha512-naLWiRfmtH4UJgtUktRTLw6FdoZJ2RvCR9ePbwM9aRMsS/KjFerkPZG9epEvXRAw5d5oPdrs9+3p+afNjxW8Xw==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.7.3",
+            "bfj": "6.1.1",
+            "chalk": "2.4.1",
+            "commander": "2.19.0",
+            "ejs": "2.6.1",
+            "express": "4.16.4",
+            "filesize": "3.6.1",
+            "gzip-size": "5.0.0",
+            "lodash": "4.17.11",
+            "mkdirp": "0.5.1",
+            "opener": "1.5.1",
+            "ws": "6.1.0"
+          }
+        },
+        "ws": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.0.tgz",
+          "integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "1.0.0"
           }
         },
         "yargs": {
@@ -2584,7 +2728,7 @@
       "integrity": "sha512-PLWJN3Xo/rycNkx+mp8iBDMTm3FeWe4VmYaZDSqL5QQB9sLsQkG5k8n+LNDFnhh9kdq2K+egL/icpctOmDHwig==",
       "requires": {
         "browserslist": "3.2.8",
-        "caniuse-lite": "1.0.30000905",
+        "caniuse-lite": "1.0.30000907",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.23",
@@ -2674,9 +2818,9 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/parser": "7.1.3",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3",
+        "@babel/parser": "7.1.5",
+        "@babel/traverse": "7.1.5",
+        "@babel/types": "7.1.5",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0"
       }
@@ -2706,7 +2850,7 @@
         },
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
         }
       }
@@ -2922,7 +3066,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "7.0.0",
-        "@babel/types": "7.1.3",
+        "@babel/types": "7.1.5",
         "glob": "7.1.3",
         "lodash": "4.17.11",
         "require-package-name": "2.0.1"
@@ -2933,7 +3077,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz",
       "integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
       "requires": {
-        "cosmiconfig": "5.0.6",
+        "cosmiconfig": "5.0.7",
         "resolve": "1.8.1"
       }
     },
@@ -3328,7 +3472,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         },
@@ -3484,9 +3628,9 @@
       }
     },
     "babel-plugin-transform-react-remove-prop-types": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.19.tgz",
-      "integrity": "sha512-f49NsaohQ1ByY20nUrpc30QFdbeT4ntV4PAL2vSZe6uCB5nqAcqXS/qzU+aI6ZfYhWASx5eIsTFvFrs1B2ffGg==",
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.20.tgz",
+      "integrity": "sha512-bWQ8e7LsgdFpyHU/RabjDAjVhL7KLAJXEt0nb0LANFje8YAGA8RlZv88a72aCswOxELWULkYuJqfFoKgs58Tng==",
       "dev": true
     },
     "babel-plugin-transform-regenerator": {
@@ -3620,14 +3764,14 @@
       }
     },
     "babel-preset-gatsby": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.1.2.tgz",
-      "integrity": "sha512-v62brsR1NvL/O5kMBkxF+GHSeXHDs5spp8EjbhWx4uNNZCwVCjehWDUowe5ZtooF52nBRqyqfWwxGkmBLTylvQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.1.3.tgz",
+      "integrity": "sha512-cE8GXHs94hBzm+xnF7wMYZkhDmV0iatsqzCI56cJP8axGvcUynsTGFC6xaXxjh2c3tOoe3IC3ce6VGyl6uiAPQ==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "7.1.0",
         "@babel/plugin-syntax-dynamic-import": "7.0.0",
         "@babel/plugin-transform-runtime": "7.1.0",
-        "@babel/preset-env": "7.1.0",
+        "@babel/preset-env": "7.1.5",
         "@babel/preset-react": "7.0.0",
         "babel-plugin-macros": "2.4.2"
       }
@@ -3647,7 +3791,7 @@
         "babel-plugin-transform-react-jsx": "6.24.1",
         "babel-plugin-transform-react-jsx-self": "6.22.0",
         "babel-plugin-transform-react-jsx-source": "6.22.0",
-        "babel-plugin-transform-react-remove-prop-types": "0.4.19",
+        "babel-plugin-transform-react-remove-prop-types": "0.4.20",
         "babel-preset-env": "1.7.0",
         "browserslist-config-google": "1.5.0"
       },
@@ -3961,12 +4105,17 @@
       }
     },
     "base-x": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-      "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
+      "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
       "requires": {
         "safe-buffer": "5.1.2"
       }
+    },
+    "base32-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.1.0.tgz",
+      "integrity": "sha512-fQWhpkWtaOPr+wvXWYDu1AfRbtIIzWDt3yDDNXLENWPwFyyxDJfVaJoOc1ks1TQckogPiHmb+0iZLQFPkZw8kg=="
     },
     "base32.js": {
       "version": "0.1.0",
@@ -4035,7 +4184,7 @@
       "integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.2",
+        "bluebird": "3.5.3",
         "check-types": "7.4.0",
         "hoopy": "0.1.4",
         "tryer": "1.0.1"
@@ -4046,7 +4195,7 @@
       "resolved": "https://registry.npmjs.org/bfj-node4/-/bfj-node4-5.3.1.tgz",
       "integrity": "sha512-SOmOsowQWfXc7ybFARsK3C4MCOWzERaOMV/Fl3Tgjs+5dJWyzo3oa127jL44eMbQiAN17J7SvAs2TRxEScTUmg==",
       "requires": {
-        "bluebird": "3.5.2",
+        "bluebird": "3.5.3",
         "check-types": "7.4.0",
         "tryer": "1.0.1"
       }
@@ -4122,9 +4271,9 @@
       }
     },
     "bl": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.1.2.tgz",
-      "integrity": "sha512-DvC0x+PxmSJNx8wXoFV15pC2+GOJ3ohb4F1REq3X32a2Z3nEBpR1Guu740M7ouYAImFj4BXDNilLNZbygtG9lQ==",
+      "version": "1.2.2",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "2.3.6",
         "safe-buffer": "5.1.2"
@@ -4141,9 +4290,9 @@
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "bluebird": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -4251,13 +4400,13 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.2.tgz",
       "integrity": "sha512-IFUbOa8PS7xqmhIjpeStwT3d09hGkNYQ6aj2iELSTxcVs2u0aKn1NzhkdUQSzsRg1FVkj3uit3I6mXQCBixw+A==",
       "requires": {
-        "hoek": "6.0.1"
+        "hoek": "6.0.2"
       },
       "dependencies": {
         "hoek": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.1.tgz",
-          "integrity": "sha512-3PvUwBerLNVJiIVQdpkWF9F/M0ekgb2NPJWOhsE28RXSQPsY42YSnaJ8d1kZjcAz58TZ/Fk9Tw64xJsENFlJNw=="
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.2.tgz",
+          "integrity": "sha512-0RGPLkyxpsMJVj/iOCaJaIWFEch988eUicJJpRiQ+Or1CMvBXcoZPlSx9FhreDWw4hxMYy8xgTEdlsYQDTnxWA=="
         }
       }
     },
@@ -4426,8 +4575,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "requires": {
-        "caniuse-lite": "1.0.30000905",
-        "electron-to-chromium": "1.3.83"
+        "caniuse-lite": "1.0.30000907",
+        "electron-to-chromium": "1.3.84"
       }
     },
     "browserslist-config-google": {
@@ -4440,7 +4589,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "requires": {
-        "base-x": "3.0.4"
+        "base-x": "3.0.5"
       }
     },
     "bs58check": {
@@ -4578,11 +4727,11 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.0.tgz",
-      "integrity": "sha512-6Af/h56f+GXGAuxfutTZGxOofff+PfaZ3K0XlXjMAzS8HHijzNYySP8zHrJ0vniSzd4wrMgwOHegWh695pHSRA==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
+      "integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
       "requires": {
-        "bluebird": "3.5.2",
+        "bluebird": "3.5.3",
         "chownr": "1.1.1",
         "figgy-pudding": "3.5.1",
         "glob": "7.1.3",
@@ -4700,9 +4849,9 @@
       }
     },
     "cached-path-relative": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
-      "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
       "dev": true
     },
     "call": {
@@ -4734,12 +4883,20 @@
       "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz",
       "integrity": "sha1-0qNphtKKppcUUmwREgm+65l50x4="
     },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "2.0.0"
+      }
+    },
+    "caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "requires": {
+        "caller-callsite": "2.0.0"
       }
     },
     "callsite": {
@@ -4748,9 +4905,9 @@
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camelcase": {
       "version": "4.1.0",
@@ -4779,7 +4936,7 @@
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "requires": {
         "browserslist": "4.3.4",
-        "caniuse-lite": "1.0.30000905",
+        "caniuse-lite": "1.0.30000907",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -4789,17 +4946,17 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
           "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83",
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84",
             "node-releases": "1.0.3"
           }
         }
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000905",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000905.tgz",
-      "integrity": "sha512-cR6ICguvhRrkAjFfBoe54vJQMVOEz7vFmqrV6oor1a7GRg6DdswI40lkiV/QQvAMb4txzTkjSaLaJaiAtSuQzA=="
+      "version": "1.0.30000907",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000907.tgz",
+      "integrity": "sha512-No5sQ/OB2Nmka8MNOOM6nJx+Hxt6MQ6h7t7kgJFu9oTuwjykyKRSBP/+i/QAyFHxeHB+ddE0Da1CG5ihx9oehQ=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -5045,6 +5202,152 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
     },
+    "cid-tool": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-0.1.0.tgz",
+      "integrity": "sha512-lss0IzW2uiLm+W8St00N23+ySnCoFTD7qPZB1WqqOSvT5mzDG8Di9e5LmcaEkNfFXh7xAmlPZmJnvWxAjVPErg==",
+      "requires": {
+        "cids": "0.5.5",
+        "explain-error": "1.0.4",
+        "multibase": "0.5.0",
+        "multihashes": "0.4.14",
+        "yargs": "12.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.6.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
+          }
+        },
+        "decamelize": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+          "requires": {
+            "xregexp": "4.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "requires": {
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "requires": {
+            "invert-kv": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+          "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+          "requires": {
+            "map-age-cleaner": "0.1.2",
+            "mimic-fn": "1.2.0",
+            "p-is-promise": "1.1.0"
+          }
+        },
+        "os-locale": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+          "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+          "requires": {
+            "execa": "0.10.0",
+            "lcid": "2.0.0",
+            "mem": "4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        },
+        "yargs": {
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+          "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "2.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "3.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "10.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
     "cids": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.5.tgz",
@@ -5266,7 +5569,7 @@
                 "remove-bom-buffer": "3.0.0",
                 "remove-bom-stream": "1.2.0",
                 "resolve-options": "1.1.0",
-                "through2": "2.0.3",
+                "through2": "2.0.5",
                 "to-through": "2.0.0",
                 "value-or-function": "3.0.0",
                 "vinyl": "2.2.0",
@@ -6041,7 +6344,7 @@
         "q": "1.5.1",
         "read-pkg": "1.1.0",
         "read-pkg-up": "1.0.1",
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       },
       "dependencies": {
         "find-up": {
@@ -6210,7 +6513,7 @@
         "meow": "4.0.1",
         "semver": "5.6.0",
         "split": "1.0.1",
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       },
       "dependencies": {
         "split": {
@@ -6245,7 +6548,7 @@
         "lodash": "4.17.11",
         "meow": "4.0.1",
         "split2": "2.2.0",
-        "through2": "2.0.3",
+        "through2": "2.0.5",
         "trim-off-newlines": "1.0.1"
       }
     },
@@ -6265,7 +6568,7 @@
         "q": "1.5.1",
         "semver": "5.6.0",
         "semver-regex": "1.0.0",
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       }
     },
     "convert-hrtime": {
@@ -6319,8 +6622,13 @@
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "noms": "0.0.0",
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       }
+    },
+    "core-decorators": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
+      "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
     },
     "core-js": {
       "version": "2.5.7",
@@ -6333,10 +6641,11 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
-      "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
+      "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
       "requires": {
+        "import-fresh": "2.0.0",
         "is-directory": "0.3.1",
         "js-yaml": "3.12.0",
         "parse-json": "4.0.0"
@@ -6700,7 +7009,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         },
         "regexpu-core": {
@@ -6762,7 +7071,7 @@
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.7.tgz",
       "integrity": "sha512-AiXL90l+MDuQmRNyypG2P7ux7K4XklxYzNNUd5HXZCNcH8/N9bHPcpN97v8tXgRVeFL/Ed8iP8mVmAAu0ZpT7A==",
       "requires": {
-        "cosmiconfig": "5.0.6",
+        "cosmiconfig": "5.0.7",
         "cssnano-preset-default": "4.0.5",
         "is-resolvable": "1.1.0",
         "postcss": "7.0.5"
@@ -6969,6 +7278,67 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/data-queue/-/data-queue-0.0.3.tgz",
       "integrity": "sha512-6YOUFa/+lXklPO42RF4zIzzphG01Jp1eoWolzkQb6z5oVsSThLibZ63VmAze3KuIMTglFt551q8j0Zaswx5vGQ=="
+    },
+    "datastore-core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.6.0.tgz",
+      "integrity": "sha512-xWMnzq4G3BQ12Nt5YYyYNGOO07pFUzPlphHJxkuwDD4NGR0pSwT4pHnTx+OndXDVsIHijTGGM8flKFE3196mvw==",
+      "requires": {
+        "async": "2.6.1",
+        "interface-datastore": "0.6.0",
+        "left-pad": "1.3.0",
+        "pull-many": "1.0.8",
+        "pull-stream": "3.6.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        }
+      }
+    },
+    "datastore-fs": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.7.0.tgz",
+      "integrity": "sha512-U8amTi/aWW391JYeFbIzjKtEqECXuMvDafD0XphsiaRKp0If4SwxgmlMn+y7BHlCRrf4/AYAwemVZBMBrSwIxA==",
+      "requires": {
+        "async": "2.6.1",
+        "datastore-core": "0.6.0",
+        "glob": "7.1.3",
+        "graceful-fs": "4.1.15",
+        "interface-datastore": "0.6.0",
+        "mkdirp": "0.5.1",
+        "pull-stream": "3.6.9",
+        "write-file-atomic": "2.3.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        }
+      }
+    },
+    "datastore-level": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.10.0.tgz",
+      "integrity": "sha512-2ZkfI3xwtRK50N7DKCu4TmohUev0gs2KIR27QaE12Zo32wNJMIHY1OV5AES/VCdC1N8raAr/JIgPAInnPb1yLQ==",
+      "requires": {
+        "datastore-core": "0.6.0",
+        "encoding-down": "5.0.4",
+        "interface-datastore": "0.6.0",
+        "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
+        "leveldown": "3.0.2",
+        "levelup": "2.0.2",
+        "pull-stream": "3.6.9"
+      }
     },
     "date-fns": {
       "version": "1.29.0",
@@ -7475,8 +7845,8 @@
       "integrity": "sha512-a3HUcoN/cdjLuiJT6EnobsZ/B0uhgmhYmLunqMw+IqAErd2AoaKp8cZcA8WFOqXAMdlmQIEmWkiINstTc3MYyQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.1.2",
-        "@babel/generator": "7.1.3",
+        "@babel/core": "7.1.5",
+        "@babel/generator": "7.1.5",
         "@babel/parser": "7.1.3",
         "@babel/plugin-proposal-class-properties": "7.1.0",
         "@babel/plugin-proposal-decorators": "7.1.2",
@@ -7494,12 +7864,12 @@
         "@babel/plugin-proposal-throw-expressions": "7.0.0",
         "@babel/plugin-syntax-dynamic-import": "7.0.0",
         "@babel/plugin-syntax-import-meta": "7.0.0",
-        "@babel/preset-env": "7.1.0",
+        "@babel/preset-env": "7.1.5",
         "@babel/preset-flow": "7.0.0",
         "@babel/preset-react": "7.0.0",
         "@babel/preset-stage-0": "7.0.0",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3",
+        "@babel/traverse": "7.1.5",
+        "@babel/types": "7.1.5",
         "ansi-html": "0.0.7",
         "babelify": "10.0.0",
         "chalk": "2.4.1",
@@ -7542,6 +7912,12 @@
         "yargs": "9.0.1"
       },
       "dependencies": {
+        "@babel/parser": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
+          "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
+          "dev": true
+        },
         "babelify": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
@@ -7613,8 +7989,8 @@
           "requires": {
             "ccount": "1.0.3",
             "comma-separated-tokens": "1.0.5",
-            "hast-util-is-element": "1.0.1",
-            "hast-util-whitespace": "1.0.1",
+            "hast-util-is-element": "1.0.2",
+            "hast-util-whitespace": "1.0.2",
             "html-void-elements": "1.0.3",
             "property-information": "4.2.0",
             "space-separated-tokens": "1.1.2",
@@ -7676,7 +8052,7 @@
           "requires": {
             "JSONStream": "1.3.5",
             "browser-resolve": "1.11.3",
-            "cached-path-relative": "1.0.1",
+            "cached-path-relative": "1.0.2",
             "concat-stream": "1.5.2",
             "defined": "1.0.0",
             "detective": "4.7.1",
@@ -7686,7 +8062,7 @@
             "resolve": "1.8.1",
             "stream-combiner2": "1.1.1",
             "subarg": "1.0.0",
-            "through2": "2.0.3",
+            "through2": "2.0.5",
             "xtend": "4.0.1"
           },
           "dependencies": {
@@ -7808,9 +8184,9 @@
           "integrity": "sha512-3V2391GL3hxKhrkzYOyfPpxJ6taIKLCfuLVqumeWQOk3H9nTtSQ8St8kMYkBVIEAquXN1chT83qJ/2lAW+dpEg==",
           "dev": true,
           "requires": {
-            "hast-util-sanitize": "1.2.0",
+            "hast-util-sanitize": "1.2.1",
             "hast-util-to-html": "4.0.1",
-            "mdast-util-to-hast": "3.0.2",
+            "mdast-util-to-hast": "3.0.4",
             "xtend": "4.0.1"
           }
         },
@@ -7864,7 +8240,7 @@
             "remove-bom-buffer": "3.0.0",
             "remove-bom-stream": "1.2.0",
             "resolve-options": "1.1.0",
-            "through2": "2.0.3",
+            "through2": "2.0.5",
             "to-through": "2.0.0",
             "value-or-function": "3.0.0",
             "vinyl": "2.2.0",
@@ -8041,7 +8417,7 @@
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
       "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
       "requires": {
-        "@babel/runtime": "7.1.2"
+        "@babel/runtime": "7.1.5"
       }
     },
     "dom-iterator": {
@@ -8211,9 +8587,9 @@
       "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.83",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.83.tgz",
-      "integrity": "sha512-DqJoDarxq50dcHsOOlMLNoy+qQitlMNbYb6wwbE0oUw2veHdRkpNrhmngiUYKMErdJ8SJ48rpJsZTQgy5SoEAA=="
+      "version": "1.3.84",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.84.tgz",
+      "integrity": "sha512-IYhbzJYOopiTaNWMBp7RjbecUBsbnbDneOP86f3qvS0G0xfzwNSvMJpTrvi5/Y1gU7tg2NAgeg8a8rCYvW9Whw=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -8299,7 +8675,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "requires": {
         "component-emitter": "1.2.1",
@@ -8354,9 +8730,9 @@
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "envinfo": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.11.1.tgz",
-      "integrity": "sha512-rmEr5fZLYYSRCj3kDhriz6ju/oMgEzC92MwF3mggFba2EMjK+CUE13MQo17Ua2CDT+KFFPAGFosodUoL/wxjug=="
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.12.1.tgz",
+      "integrity": "sha512-pwdo0/G3CIkQ0y6PCXq4RdkvId2elvtPCJMG0konqlrfkWQbf1DWeH9K2b/cvu2YgGvPPTOnonZxXM1gikFu1w=="
     },
     "eol": {
       "version": "0.8.1",
@@ -9004,9 +9380,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "ethereum-common": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
     },
     "ethereumjs-account": {
       "version": "2.0.5",
@@ -9019,12 +9395,12 @@
       }
     },
     "ethereumjs-block": {
-      "version": "1.7.1",
-      "resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
-      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.1.0.tgz",
+      "integrity": "sha512-ip+x4/7hUInX+TQfhEKsQh9MJK1Dbjp4AuPjf1UdX3udAV4beYD4EMCNIPzBLCsGS8WQZYXLpo83tVTISYNpow==",
       "requires": {
         "async": "2.6.1",
-        "ethereum-common": "0.2.0",
+        "ethereumjs-common": "0.6.0",
         "ethereumjs-tx": "1.3.7",
         "ethereumjs-util": "5.2.0",
         "merkle-patricia-tree": "2.3.2"
@@ -9040,6 +9416,11 @@
         }
       }
     },
+    "ethereumjs-common": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-0.6.0.tgz",
+      "integrity": "sha512-KN1BScZ6bMUIBMP7a2hNJYhpcY/TvXxU/9B0t9xOyytheIWOaJynVLwStma/oHICIlStSmfbwLvP0CPbek+IXQ=="
+    },
     "ethereumjs-tx": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
@@ -9047,13 +9428,6 @@
       "requires": {
         "ethereum-common": "0.0.18",
         "ethereumjs-util": "5.2.0"
-      },
-      "dependencies": {
-        "ethereum-common": {
-          "version": "0.0.18",
-          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-        }
       }
     },
     "ethereumjs-util": {
@@ -9288,6 +9662,11 @@
       "requires": {
         "homedir-polyfill": "1.0.1"
       }
+    },
+    "explain-error": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
+      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
     },
     "express": {
       "version": "4.16.4",
@@ -9576,7 +9955,7 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "requires": {
-        "flat-cache": "1.3.0",
+        "flat-cache": "1.3.2",
         "object-assign": "4.1.1"
       }
     },
@@ -9639,9 +10018,9 @@
       }
     },
     "file-type": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
-      "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.4.0.tgz",
+      "integrity": "sha512-/Ha0T7TRFOFKgj36icy46h93By2tTwHirW9qeNLslo5NYmd7BbITVv2tkcuohmZWsNLqg9/dKNKwRXF3OVgVdA=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -9829,48 +10208,14 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.2.tgz",
+      "integrity": "sha512-KByBY8c98sLUAGpnmjEdWTrtrLZRtZdwds+kAL/ciFXTCb7AZgqKsAnVnYFQj1hxepwO8JKN/8AsRWwLq+RK0A==",
       "requires": {
         "circular-json": "0.3.3",
-        "del": "2.2.2",
+        "del": "3.0.0",
         "graceful-fs": "4.1.15",
         "write": "0.2.1"
-      },
-      "dependencies": {
-        "del": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-          "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.1",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.6.2"
-          }
-        },
-        "globby": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.3",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "flatmap": {
@@ -10021,7 +10366,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -10042,6 +10387,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
       "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
+    },
+    "fs-ext": {
+      "version": "github:baudehlo/node-fs-ext#2ba366d9fc67ef3ab165e239068924b276ecf249",
+      "optional": true,
+      "requires": {
+        "nan": "2.11.1"
+      }
     },
     "fs-extra": {
       "version": "5.0.0",
@@ -10068,7 +10420,7 @@
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.15",
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       }
     },
     "fs-readdir-recursive": {
@@ -10587,16 +10939,16 @@
       "integrity": "sha512-zDpwk/l3HbhjVAvdxNUTJFzgXiNy0a7EmE/50XT38o1z+7NJbFhp+8CDsv1Qgy2adBAwUVYlMpIX2fZUbmlUJw=="
     },
     "gatsby": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.0.38.tgz",
-      "integrity": "sha512-igJipwITl/C24l66cDeEBYLzk5hR2e1ZkHgUwEoFaR360ix/+S9kKwCo2Cb58ywYefdhxWPYAWT+ZinYGHujeQ==",
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.0.44.tgz",
+      "integrity": "sha512-R8n2LuxKZvHYDOGgz0sTPGIWE6Rjt3P3oXDhhiifCvElcB5gh2QV8YxPXq7XATR13nstHpDEHgDSfI2Ls5NoGg==",
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/core": "7.1.2",
-        "@babel/parser": "7.1.3",
+        "@babel/core": "7.1.5",
+        "@babel/parser": "7.1.5",
         "@babel/polyfill": "7.0.0",
-        "@babel/runtime": "7.1.2",
-        "@babel/traverse": "7.1.4",
+        "@babel/runtime": "7.1.5",
+        "@babel/traverse": "7.1.5",
         "@reach/router": "1.2.1",
         "autoprefixer": "8.6.5",
         "babel-core": "7.0.0-bridge.0",
@@ -10605,9 +10957,9 @@
         "babel-plugin-add-module-exports": "0.2.1",
         "babel-plugin-dynamic-import-node": "1.2.0",
         "babel-plugin-remove-graphql-queries": "2.5.1",
-        "babel-preset-gatsby": "0.1.2",
+        "babel-preset-gatsby": "0.1.3",
         "better-queue": "3.8.10",
-        "bluebird": "3.5.2",
+        "bluebird": "3.5.3",
         "cache-manager": "2.9.0",
         "cache-manager-fs-hash": "0.0.6",
         "chalk": "2.4.1",
@@ -10639,9 +10991,9 @@
         "flat": "4.1.0",
         "friendly-errors-webpack-plugin": "1.7.0",
         "fs-extra": "5.0.0",
-        "gatsby-cli": "2.4.4",
+        "gatsby-cli": "2.4.5",
         "gatsby-link": "2.0.6",
-        "gatsby-plugin-page-creator": "2.0.2",
+        "gatsby-plugin-page-creator": "2.0.4",
         "gatsby-react-router-scroll": "2.0.1",
         "glob": "7.1.3",
         "graphql": "0.13.2",
@@ -10695,7 +11047,7 @@
         "url-loader": "1.1.2",
         "uuid": "3.3.2",
         "v8-compile-cache": "1.1.2",
-        "webpack": "4.25.0",
+        "webpack": "4.25.1",
         "webpack-dev-middleware": "3.4.0",
         "webpack-dev-server": "3.1.10",
         "webpack-hot-middleware": "2.24.3",
@@ -10710,7 +11062,7 @@
           "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
           "requires": {
             "@babel/types": "7.0.0-beta.44",
-            "jsesc": "2.5.1",
+            "jsesc": "2.5.2",
             "lodash": "4.17.11",
             "source-map": "0.5.7",
             "trim-right": "1.0.1"
@@ -10894,17 +11246,17 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.4.4.tgz",
-          "integrity": "sha512-8ojdIws8dOROqmY47ztMx4a/BVvCf7+sRrhAXSBGCC/KZSjTb+CzVDkEmPB4q8Z8DeoCO3Xp7auq3JcuMVqXWw==",
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.4.5.tgz",
+          "integrity": "sha512-r1s79aXjPgur561UuBi8iTvGr+VIxqzKRBWYNxuWQADC352LGk/j5qTFdwC/jgfIQDE0Ue7hWC9UM1LYntdVcw==",
           "requires": {
             "@babel/code-frame": "7.0.0",
-            "@babel/runtime": "7.1.2",
-            "bluebird": "3.5.2",
+            "@babel/runtime": "7.1.5",
+            "bluebird": "3.5.3",
             "common-tags": "1.8.0",
             "convert-hrtime": "2.0.0",
             "core-js": "2.5.7",
-            "envinfo": "5.11.1",
+            "envinfo": "5.12.1",
             "execa": "0.8.0",
             "fs-exists-cached": "1.0.0",
             "fs-extra": "4.0.3",
@@ -10952,9 +11304,9 @@
       "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.0.6.tgz",
       "integrity": "sha512-JZM1FLjAH1zDIyUAV9QGpufxoQ3q7JmWtnXW+op5PZTjC1aLJefKYwkTYExYJ6v+ti1ketTauE2eckjQgKiO4w==",
       "requires": {
-        "@babel/runtime": "7.1.2",
+        "@babel/runtime": "7.1.5",
         "@reach/router": "1.2.1",
-        "@types/reach__router": "1.2.1",
+        "@types/reach__router": "1.2.2",
         "prop-types": "15.6.2"
       }
     },
@@ -10990,34 +11342,35 @@
       }
     },
     "gatsby-plugin-layout": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-layout/-/gatsby-plugin-layout-1.0.7.tgz",
-      "integrity": "sha512-pylB9VI/XWot8wdutNwYWGeMGNRcInI0PuxVl4kl5W2SEumWUvIW6rVp9E8gqox9XDXN4I58fEGmF3mlGVH9lQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-layout/-/gatsby-plugin-layout-1.0.8.tgz",
+      "integrity": "sha512-I4KtZu4rUJ8LTP7JlTJWxj5LquudouBDdsyrMBKHbE1rrZ0A7kxAEE+jtEpmcLSQYf72t1cm9pEx7/XyiHhdnA==",
       "requires": {
-        "@babel/runtime": "7.1.2"
+        "@babel/runtime": "7.1.5"
       }
     },
     "gatsby-plugin-manifest": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.0.7.tgz",
-      "integrity": "sha512-vVSyGv5vU6jyARbI54DIVWVh+zkd23ItGb040iuS5uQS96gvz3UB7n3B5z4HBt/xV084eMoT7tuSOGncahoVbQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.0.8.tgz",
+      "integrity": "sha512-vDGK+Vv8nBAPNLTRALQfSi2//HSk5XX6SlFoG7yihg84H6gNgctEjYiz1IkdUDiMlgqgviQYJlgSorKfHYC57A==",
       "requires": {
-        "@babel/runtime": "7.1.2",
-        "bluebird": "3.5.2",
+        "@babel/runtime": "7.1.5",
+        "bluebird": "3.5.3",
         "sharp": "0.21.0"
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.0.2.tgz",
-      "integrity": "sha512-xPavO/Hokpw3CUKi7Zx/JneuBBGqG250LgzdCu+2BLB8A401OzOM4g84kUOXVj2OvoPzRpXiRqU7+a/lkuUAyA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.0.4.tgz",
+      "integrity": "sha512-WgU1o4hvqPT2JjUdyF1yPXaVeELvObZkYKkUNMx+RDf5WVcyyuE+s+7cEAH+80c8x5lgPrLIbe4/qxrFtPWSHQ==",
       "requires": {
-        "@babel/runtime": "7.1.2",
-        "bluebird": "3.5.2",
+        "@babel/runtime": "7.1.5",
+        "bluebird": "3.5.3",
         "chokidar": "1.7.0",
         "fs-exists-cached": "1.0.0",
         "glob": "7.1.3",
         "lodash": "4.17.11",
+        "micromatch": "3.1.10",
         "parse-filepath": "1.0.2",
         "slash": "1.0.0"
       },
@@ -11029,6 +11382,28 @@
           "requires": {
             "micromatch": "2.3.11",
             "normalize-path": "2.1.1"
+          },
+          "dependencies": {
+            "micromatch": {
+              "version": "2.3.11",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+              "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+              "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+              }
+            }
           }
         },
         "arr-diff": {
@@ -11114,26 +11489,6 @@
           "requires": {
             "is-buffer": "1.1.6"
           }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
         }
       }
     },
@@ -11142,7 +11497,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-postcss/-/gatsby-plugin-postcss-2.0.1.tgz",
       "integrity": "sha512-IRkz3S4aWhKYFzn89JgcLu4Dgla2BohMIE+bCzeb0jfi8qZNZWpZ8ukTbEnKP24vuvAUXouWkKt3kjwIh4nuww==",
       "requires": {
-        "@babel/runtime": "7.1.2",
+        "@babel/runtime": "7.1.5",
         "postcss-loader": "3.0.0"
       },
       "dependencies": {
@@ -11215,7 +11570,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.0.1.tgz",
       "integrity": "sha512-wZRqSUvMgurFsa4z4VWTGrExWife6nHoS1CxMGm6HagqSNwkpJRbzXWUG5hsyry9jNi3x5Tm9TzcjD4NdcM2vg==",
       "requires": {
-        "@babel/runtime": "7.1.2"
+        "@babel/runtime": "7.1.5"
       }
     },
     "gatsby-plugin-webpack-bundle-analyzer": {
@@ -11224,45 +11579,6 @@
       "integrity": "sha512-h5dpD1o7eIukJdHKamij345iyr4VhKEmYTn6SWsusFnceJKFSZCIP13ixdAvbcimsO9CkDBjpSeNdSx7AzB5BA==",
       "requires": {
         "webpack-bundle-analyzer": "2.13.1"
-      },
-      "dependencies": {
-        "gzip-size": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.1.0.tgz",
-          "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
-          "requires": {
-            "duplexer": "0.1.1",
-            "pify": "3.0.0"
-          }
-        },
-        "webpack-bundle-analyzer": {
-          "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.13.1.tgz",
-          "integrity": "sha512-rwxyfecTAxoarCC9VlHlIpfQCmmJ/qWD5bpbjkof+7HrNhTNZIwZITxN6CdlYL2axGmwNUQ+tFgcSOiNXMf/sQ==",
-          "requires": {
-            "acorn": "5.7.3",
-            "bfj-node4": "5.3.1",
-            "chalk": "2.4.1",
-            "commander": "2.19.0",
-            "ejs": "2.6.1",
-            "express": "4.16.4",
-            "filesize": "3.5.11",
-            "gzip-size": "4.1.0",
-            "lodash": "4.17.11",
-            "mkdirp": "0.5.1",
-            "opener": "1.5.1",
-            "ws": "4.1.0"
-          }
-        },
-        "ws": {
-          "version": "4.1.0",
-          "resolved": "http://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-          "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.2"
-          }
-        }
       }
     },
     "gatsby-react-router-scroll": {
@@ -11270,7 +11586,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.0.1.tgz",
       "integrity": "sha512-Q31vH0/PF1dMm18GdxUe/lkS+ri6tTq16JCFpUMSVEkob5V1zo7PDYR2+j/OHI0NnQWJQs5nm/kQ7/D08WMI1A==",
       "requires": {
-        "@babel/runtime": "7.1.2",
+        "@babel/runtime": "7.1.5",
         "scroll-behavior": "0.9.9",
         "warning": "3.0.0"
       }
@@ -11834,7 +12150,7 @@
         "meow": "3.7.0",
         "normalize-package-data": "2.4.0",
         "parse-github-repo-url": "1.4.1",
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       },
       "dependencies": {
         "camelcase": {
@@ -12095,7 +12411,7 @@
         "commander": "2.19.0",
         "email-addresses": "3.0.2",
         "filenamify-url": "1.0.0",
-        "fs-extra": "7.0.0",
+        "fs-extra": "7.0.1",
         "globby": "6.1.0",
         "graceful-fs": "4.1.15",
         "rimraf": "2.6.2"
@@ -12111,9 +12427,9 @@
           }
         },
         "fs-extra": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-          "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.15",
@@ -12133,7 +12449,7 @@
         "lodash.template": "4.4.0",
         "meow": "4.0.1",
         "split2": "2.2.0",
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       }
     },
     "git-remote-origin-url": {
@@ -12491,7 +12807,7 @@
       "resolved": "https://registry.npmjs.org/graphql-skip-limit/-/graphql-skip-limit-2.0.1.tgz",
       "integrity": "sha512-a+RbtflaCGqmahK7w0M23kXNv4MV17pCPz0EnyQ/Ve79/k2c9EHNjfwj8hWk+jAXoxZ1SDJeUoeFAZhS9kwljA==",
       "requires": {
-        "@babel/runtime": "7.1.2"
+        "@babel/runtime": "7.1.5"
       }
     },
     "graphql-tools": {
@@ -12531,7 +12847,7 @@
         "convert-source-map": "1.6.0",
         "graceful-fs": "4.1.15",
         "strip-bom": "2.0.0",
-        "through2": "2.0.3",
+        "through2": "2.0.5",
         "vinyl": "1.2.0"
       },
       "dependencies": {
@@ -12579,7 +12895,7 @@
     },
     "handle-thing": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
     },
     "handlebars": {
@@ -12834,15 +13150,15 @@
       "integrity": "sha1-EPIJmg18BaQPK+r1wdOc8vfavzY="
     },
     "hast-util-is-element": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.1.tgz",
-      "integrity": "sha512-s/ggaNehYVqmLgTXEv12Lbb72bsOD2r5DhAqPgtDdaI/YFNXVzz0zHFVJnhjIjn7Nak8GbL4nzT2q0RA5div+A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.2.tgz",
+      "integrity": "sha512-4MEtyofNi3ZunPFrp9NpTQdNPN24xvLX3M+Lr/RGgPX6TLi+wR4/DqeoyQ7lwWcfUp4aevdt4RR0r7ZQPFbHxw==",
       "dev": true
     },
     "hast-util-sanitize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.2.0.tgz",
-      "integrity": "sha512-VwCTqjt6fbMGacxGB1FKV5sBJaVVkyCGVMDwb4nnqvCW2lkqscA2GEpOyBx4ZWRXty1eAZF58MHBrllEoQEoBg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.2.1.tgz",
+      "integrity": "sha512-bRyZ316tTETfxkpM0De0Fk5slEtR5hvkzDGbHpEAjZRmfQyT3xMTzMk0/gGWlkqsfafFCaPNbrtPdZBPMK8X8A==",
       "dev": true,
       "requires": {
         "xtend": "4.0.1"
@@ -12856,8 +13172,8 @@
       "requires": {
         "ccount": "1.0.3",
         "comma-separated-tokens": "1.0.5",
-        "hast-util-is-element": "1.0.1",
-        "hast-util-whitespace": "1.0.1",
+        "hast-util-is-element": "1.0.2",
+        "hast-util-whitespace": "1.0.2",
         "html-void-elements": "1.0.3",
         "kebab-case": "1.0.0",
         "property-information": "3.2.0",
@@ -12868,9 +13184,9 @@
       }
     },
     "hast-util-whitespace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.1.tgz",
-      "integrity": "sha512-Mfx2ZnmVMTAopZ8as42nKrNt650tCZYhy/MPeO1Imdg/cmCWK6GUSnFrrE3ezGjVifn7x5zMfu8jrjwIGyImSw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.2.tgz",
+      "integrity": "sha512-4JT8B0HKPHBMFZdDQzexjxwhKx9TrpV/+uelvmqlPu8RqqDrnNIEHDtDZCmgE+4YmcFAtKVPLmnY3dQGRaN53A==",
       "dev": true
     },
     "he": {
@@ -13186,7 +13502,7 @@
     },
     "humanize-url": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
       "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
       "dev": true,
       "requires": {
@@ -13290,6 +13606,12 @@
         "replace-ext": "1.0.0"
       },
       "dependencies": {
+        "file-type": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
+          "dev": true
+        },
         "globby": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
@@ -13335,19 +13657,21 @@
         "import-from": "2.1.0"
       }
     },
+    "import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "requires": {
+        "caller-path": "2.0.0",
+        "resolve-from": "3.0.0"
+      }
+    },
     "import-from": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "requires": {
         "resolve-from": "3.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-        }
       }
     },
     "import-lazy": {
@@ -13688,19 +14012,591 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
+    "ipfs": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.33.1.tgz",
+      "integrity": "sha512-He22aMi/qJYcao4zkh9fS1cZZWKPWIyO964j/Bt+DhEUVO79DBBGW+PuF3I8IfVE8ihDxImxNboal3pbZT9EdA==",
+      "requires": {
+        "@nodeutils/defaults-deep": "1.1.0",
+        "async": "2.6.1",
+        "big.js": "5.2.2",
+        "binary-querystring": "0.1.2",
+        "bl": "2.1.2",
+        "boom": "7.2.2",
+        "bs58": "4.0.1",
+        "byteman": "1.3.5",
+        "cid-tool": "0.1.0",
+        "cids": "0.5.5",
+        "debug": "4.1.0",
+        "err-code": "1.1.2",
+        "file-type": "10.4.0",
+        "fnv1a": "1.0.1",
+        "fsm-event": "2.1.0",
+        "get-folder-size": "2.0.0",
+        "glob": "7.1.3",
+        "hapi": "16.7.0",
+        "hapi-set-header": "1.0.2",
+        "hoek": "5.0.4",
+        "human-to-milliseconds": "1.0.0",
+        "interface-datastore": "0.6.0",
+        "ipfs-api": "26.1.2",
+        "ipfs-bitswap": "0.21.0",
+        "ipfs-block": "0.8.0",
+        "ipfs-block-service": "0.15.2",
+        "ipfs-http-response": "0.2.0",
+        "ipfs-mfs": "0.4.2",
+        "ipfs-multipart": "0.1.0",
+        "ipfs-repo": "0.25.0",
+        "ipfs-unixfs": "0.1.16",
+        "ipfs-unixfs-engine": "0.33.0",
+        "ipld": "0.19.3",
+        "ipld-bitcoin": "0.1.8",
+        "ipld-dag-pb": "0.14.11",
+        "ipld-ethereum": "2.0.2",
+        "ipld-git": "0.2.2",
+        "ipld-raw": "2.0.1",
+        "ipld-zcash": "0.1.6",
+        "ipns": "0.3.0",
+        "is-ipfs": "0.4.7",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "1.1.0",
+        "joi": "13.7.0",
+        "joi-browser": "13.4.0",
+        "joi-multiaddr": "2.0.0",
+        "libp2p": "0.23.1",
+        "libp2p-bootstrap": "0.9.3",
+        "libp2p-crypto": "0.14.1",
+        "libp2p-kad-dht": "0.10.6",
+        "libp2p-keychain": "0.3.3",
+        "libp2p-mdns": "0.12.0",
+        "libp2p-mplex": "0.8.3",
+        "libp2p-record": "0.6.1",
+        "libp2p-secio": "0.10.1",
+        "libp2p-tcp": "0.13.0",
+        "libp2p-webrtc-star": "0.15.5",
+        "libp2p-websocket-star": "0.9.0",
+        "libp2p-websockets": "0.12.0",
+        "lodash": "4.17.11",
+        "mafmt": "6.0.2",
+        "mime-types": "2.1.21",
+        "mkdirp": "0.5.1",
+        "multiaddr": "5.0.2",
+        "multiaddr-to-uri": "4.0.0",
+        "multibase": "0.5.0",
+        "multihashes": "0.4.14",
+        "once": "1.4.0",
+        "peer-book": "0.8.0",
+        "peer-id": "0.12.0",
+        "peer-info": "0.14.1",
+        "progress": "2.0.1",
+        "prom-client": "11.1.3",
+        "prometheus-gc-stats": "0.6.0",
+        "promisify-es6": "1.0.3",
+        "pull-abortable": "4.1.1",
+        "pull-catch": "1.0.0",
+        "pull-defer": "0.2.3",
+        "pull-file": "1.1.0",
+        "pull-ndjson": "0.1.1",
+        "pull-paramap": "1.2.2",
+        "pull-pushable": "2.2.0",
+        "pull-sort": "1.0.2",
+        "pull-stream": "3.6.9",
+        "pull-stream-to-stream": "1.3.4",
+        "pull-zip": "2.0.1",
+        "pump": "3.0.0",
+        "read-pkg-up": "4.0.0",
+        "readable-stream": "3.0.6",
+        "receptacle": "1.3.2",
+        "stream-to-pull-stream": "1.7.2",
+        "tar-stream": "1.6.2",
+        "temp": "0.8.3",
+        "update-notifier": "2.5.0",
+        "yargs": "12.0.2",
+        "yargs-promise": "1.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        },
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
+        "bl": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.1.2.tgz",
+          "integrity": "sha512-DvC0x+PxmSJNx8wXoFV15pC2+GOJ3ohb4F1REq3X32a2Z3nEBpR1Guu740M7ouYAImFj4BXDNilLNZbygtG9lQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "safe-buffer": "5.1.2"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
+              }
+            }
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.6.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "decamelize": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+          "requires": {
+            "xregexp": "4.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "requires": {
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "3.0.0"
+          }
+        },
+        "hoek": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+        },
+        "joi": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+          "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+          "requires": {
+            "hoek": "5.0.4",
+            "isemail": "3.2.0",
+            "topo": "3.0.3"
+          }
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "requires": {
+            "invert-kv": "2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "requires": {
+            "graceful-fs": "4.1.15",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+          "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+          "requires": {
+            "map-age-cleaner": "0.1.2",
+            "mimic-fn": "1.2.0",
+            "p-is-promise": "1.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "os-locale": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+          "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+          "requires": {
+            "execa": "0.10.0",
+            "lcid": "2.0.0",
+            "mem": "4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "requires": {
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+          "requires": {
+            "find-up": "3.0.0",
+            "read-pkg": "3.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "requires": {
+            "inherits": "2.0.3",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "topo": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+          "requires": {
+            "hoek": "6.0.2"
+          },
+          "dependencies": {
+            "hoek": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.2.tgz",
+              "integrity": "sha512-0RGPLkyxpsMJVj/iOCaJaIWFEch988eUicJJpRiQ+Or1CMvBXcoZPlSx9FhreDWw4hxMYy8xgTEdlsYQDTnxWA=="
+            }
+          }
+        },
+        "yargs": {
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+          "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "2.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "3.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "10.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
+    "ipfs-api": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-26.1.2.tgz",
+      "integrity": "sha512-HkM6vQOHL9z9ZCXIrbDXvAOsIzfWPaAac9kY+SjUuVqMydWHzP8qTxfv5jaXResGbmLcbwcROhuqgJU+HrclSg==",
+      "requires": {
+        "async": "2.6.1",
+        "big.js": "5.2.2",
+        "bl": "2.1.2",
+        "bs58": "4.0.1",
+        "cids": "0.5.5",
+        "concat-stream": "1.6.2",
+        "debug": "4.1.0",
+        "detect-node": "2.0.4",
+        "end-of-stream": "1.4.1",
+        "flatmap": "0.0.3",
+        "glob": "7.1.3",
+        "ipfs-block": "0.8.0",
+        "ipfs-unixfs": "0.1.16",
+        "ipld-dag-cbor": "0.13.0",
+        "ipld-dag-pb": "0.14.11",
+        "is-ipfs": "0.4.7",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "1.1.0",
+        "libp2p-crypto": "0.14.1",
+        "lodash": "4.17.11",
+        "lru-cache": "4.1.3",
+        "multiaddr": "5.0.2",
+        "multibase": "0.5.0",
+        "multihashes": "0.4.14",
+        "ndjson": "1.5.0",
+        "once": "1.4.0",
+        "peer-id": "0.12.0",
+        "peer-info": "0.14.1",
+        "promisify-es6": "1.0.3",
+        "pull-defer": "0.2.3",
+        "pull-pushable": "2.2.0",
+        "pull-stream-to-stream": "1.3.4",
+        "pump": "3.0.0",
+        "qs": "6.5.2",
+        "readable-stream": "3.0.6",
+        "stream-http": "3.0.0",
+        "stream-to-pull-stream": "1.7.2",
+        "streamifier": "0.1.1",
+        "tar-stream": "1.6.2",
+        "through2": "2.0.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        },
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
+        "bl": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.1.2.tgz",
+          "integrity": "sha512-DvC0x+PxmSJNx8wXoFV15pC2+GOJ3ohb4F1REq3X32a2Z3nEBpR1Guu740M7ouYAImFj4BXDNilLNZbygtG9lQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "safe-buffer": "5.1.2"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "readable-stream": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "requires": {
+            "inherits": "2.0.3",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "stream-http": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.0.0.tgz",
+          "integrity": "sha512-JELJfd+btL9GHtxU3+XXhg9NLYrKFnhybfvRuDghtyVkOFydz3PKNT1df07AMr88qW03WHF+FSV0PySpXignCA==",
+          "requires": {
+            "builtin-status-codes": "3.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "3.0.6",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "ipfs-bitswap": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.21.0.tgz",
+      "integrity": "sha512-gsKGv3pa98jVQZURZcubW/LPpj0SX2UjISosF+7Nnmp4oR1RtTNBIhY+OyvlNGMWo8BqfVZb/iB0Z1+FME6CAw==",
+      "requires": {
+        "async": "2.6.1",
+        "big.js": "5.2.2",
+        "cids": "0.5.5",
+        "debug": "4.1.0",
+        "ipfs-block": "0.8.0",
+        "lodash.debounce": "4.0.8",
+        "lodash.find": "4.6.0",
+        "lodash.groupby": "4.6.0",
+        "lodash.isequalwith": "4.4.0",
+        "lodash.isundefined": "3.0.1",
+        "lodash.pullallwith": "4.7.0",
+        "lodash.sortby": "4.7.0",
+        "lodash.uniqwith": "4.5.0",
+        "lodash.values": "4.3.0",
+        "moving-average": "1.0.0",
+        "multicodec": "0.2.7",
+        "multihashing-async": "0.5.1",
+        "protons": "1.0.1",
+        "pull-defer": "0.2.3",
+        "pull-length-prefixed": "1.3.1",
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.9",
+        "varint-decoder": "0.1.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        },
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "ipfs-block": {
-      "version": "0.7.1",
-      "resolved": "http://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
-      "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.0.tgz",
+      "integrity": "sha512-znNtFRxXlJYP1/Q4u0tGFJUceH9pNww8WA+zair6T3y7d28m+vtUDJGn96M7ZlFFSkByQyQsAiq2ssNhKtMzxw==",
       "requires": {
         "cids": "0.5.5",
         "class-is": "1.1.0"
       }
     },
+    "ipfs-block-service": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.15.2.tgz",
+      "integrity": "sha512-iudmJO7UJZHonWoXyakuzy+bpV/7QVDm/g8eCqKN2BvhSjnLepaxdTyaXxJ76F2EOav1hdBP+U3Z9Mg/aCFPgg==",
+      "requires": {
+        "async": "2.6.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        }
+      }
+    },
     "ipfs-http-response": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.1.4.tgz",
-      "integrity": "sha512-qVi0AK3evZBbHljePgmeFy6o8RBVTOmPXUgRNHrwFr99DmJHPhbgJ/Wse0vpQsKwo3dd1m7RP33GHE9Xd1vmPA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.2.0.tgz",
+      "integrity": "sha512-E4atwGKflYNzynrJQ6VYguREiPWgQDmgXOwEsGOM8EdHHQWOkWsPNl6CGnlHGC2ESj0iUJx1CYMmXNmNzzOlGQ==",
       "requires": {
         "async": "2.6.1",
         "cids": "0.5.5",
@@ -13723,10 +14619,127 @@
             "lodash": "4.17.11"
           }
         },
+        "file-type": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
+        },
         "filesize": {
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
           "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
+        }
+      }
+    },
+    "ipfs-mfs": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.4.2.tgz",
+      "integrity": "sha512-6xcexwgnyXXbi3PeXfmCtKa8nMijm8lvRPvfm27/Jwv/gLU1sJkpI6KF0m/EBeM7mwl1pQYu4E03qVoz8hDxtA==",
+      "requires": {
+        "async": "2.6.1",
+        "blob": "0.0.5",
+        "cids": "0.5.5",
+        "debug": "4.1.0",
+        "file-api": "0.10.4",
+        "filereader-stream": "2.0.0",
+        "interface-datastore": "0.6.0",
+        "ipfs-unixfs": "0.1.16",
+        "ipfs-unixfs-engine": "0.32.8",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "1.1.0",
+        "joi": "13.7.0",
+        "joi-browser": "13.4.0",
+        "mortice": "1.2.1",
+        "once": "1.4.0",
+        "promisify-es6": "1.0.3",
+        "pull-cat": "1.1.11",
+        "pull-defer": "0.2.3",
+        "pull-paramap": "1.2.2",
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.9",
+        "pull-stream-to-stream": "1.3.4",
+        "pull-traverse": "1.0.3",
+        "stream-to-pull-stream": "1.7.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        },
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "hoek": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+        },
+        "ipfs-unixfs-engine": {
+          "version": "0.32.8",
+          "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.32.8.tgz",
+          "integrity": "sha512-YqLppNmG5M0rFj7QOTdRjny8xNKxmqKJE5DCOtc2ZMaXd4Semq+rEH23N2Mr1jYpimboDnadcv6jszi5cWRexw==",
+          "requires": {
+            "async": "2.6.1",
+            "cids": "0.5.5",
+            "deep-extend": "0.6.0",
+            "ipfs-unixfs": "0.1.16",
+            "ipld-dag-pb": "0.14.11",
+            "left-pad": "1.3.0",
+            "multihashing-async": "0.5.1",
+            "pull-batch": "1.0.0",
+            "pull-block": "1.4.0",
+            "pull-cat": "1.1.11",
+            "pull-pair": "1.1.0",
+            "pull-paramap": "1.2.2",
+            "pull-pause": "0.0.2",
+            "pull-pushable": "2.2.0",
+            "pull-stream": "3.6.9",
+            "pull-through": "1.0.18",
+            "pull-traverse": "1.0.3",
+            "pull-write": "1.1.4",
+            "rabin": "1.6.0",
+            "sparse-array": "1.3.1",
+            "stream-to-pull-stream": "1.7.2"
+          }
+        },
+        "joi": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+          "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+          "requires": {
+            "hoek": "5.0.4",
+            "isemail": "3.2.0",
+            "topo": "3.0.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "topo": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+          "requires": {
+            "hoek": "6.0.2"
+          },
+          "dependencies": {
+            "hoek": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.2.tgz",
+              "integrity": "sha512-0RGPLkyxpsMJVj/iOCaJaIWFEch988eUicJJpRiQ+Or1CMvBXcoZPlSx9FhreDWw4hxMYy8xgTEdlsYQDTnxWA=="
+            }
+          }
         }
       }
     },
@@ -13787,6 +14800,15 @@
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
           "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
+        "ipfs-block": {
+          "version": "0.7.1",
+          "resolved": "http://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
+          "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
+          "requires": {
+            "cids": "0.5.5",
+            "class-is": "1.1.0"
+          }
         },
         "libp2p-crypto": {
           "version": "0.12.1",
@@ -13851,9 +14873,67 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        }
+      }
+    },
+    "ipfs-repo": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.25.0.tgz",
+      "integrity": "sha512-P/QGkWTaI5Vp9HLQssCkxhmbu0uZ3fINQWooSAAk3Kp647OIgXC5CWXALA/xlxAsyn1PxqlHZ9yLFOc8eJP5wg==",
+      "requires": {
+        "async": "2.6.1",
+        "base32.js": "0.1.0",
+        "big.js": "5.2.2",
+        "cids": "0.5.5",
+        "datastore-core": "0.6.0",
+        "datastore-fs": "0.7.0",
+        "datastore-level": "0.10.0",
+        "debug": "4.1.0",
+        "interface-datastore": "0.6.0",
+        "ipfs-block": "0.7.1",
+        "lock-me": "1.0.4",
+        "lodash.get": "4.4.2",
+        "lodash.has": "4.5.2",
+        "lodash.set": "4.3.2",
+        "multiaddr": "5.0.2",
+        "pull-stream": "3.6.9",
+        "sort-keys": "2.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
         },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "ipfs-block": {
+          "version": "0.7.1",
+          "resolved": "http://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
+          "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
+          "requires": {
+            "cids": "0.5.5",
+            "class-is": "1.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -13863,6 +14943,74 @@
       "integrity": "sha512-TX9Dyu77MxpLzGh/LcQne95TofOyvOeW0oOi72aBMMcV1ItP3684e6NTG9KY1qzdrC+ZUR8kT7y18J058n8KXg==",
       "requires": {
         "protons": "1.0.1"
+      }
+    },
+    "ipfs-unixfs-engine": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.33.0.tgz",
+      "integrity": "sha512-NF4e9PB4I22Ca1qaGeCG0pBQOaYTpBWwgC+EKlAomwj6FD6BeFD4OpoaEAs9kp8dOdjY8yKrHe+tRg9AGgOoIw==",
+      "requires": {
+        "async": "2.6.1",
+        "cids": "0.5.5",
+        "deep-extend": "0.6.0",
+        "ipfs-unixfs": "0.1.16",
+        "ipld-dag-pb": "0.14.11",
+        "left-pad": "1.3.0",
+        "multihashing-async": "0.5.1",
+        "pull-batch": "1.0.0",
+        "pull-block": "1.4.0",
+        "pull-cat": "1.1.11",
+        "pull-pair": "1.1.0",
+        "pull-paramap": "1.2.2",
+        "pull-pause": "0.0.2",
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.9",
+        "pull-through": "1.0.18",
+        "pull-traverse": "1.0.3",
+        "pull-write": "1.1.4",
+        "rabin": "1.6.0",
+        "sparse-array": "1.3.1",
+        "stream-to-pull-stream": "1.7.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        }
+      }
+    },
+    "ipld": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.19.3.tgz",
+      "integrity": "sha512-MK7hKGT2bUFs82XjVgM+12RhrAALVAdS/2bXJX4zJR0hPSXe/jXIqv83DijLk98zEjMujoPxh/Er+VVXNSr4gw==",
+      "requires": {
+        "async": "2.6.1",
+        "cids": "0.5.5",
+        "interface-datastore": "0.6.0",
+        "ipfs-block": "0.8.0",
+        "ipfs-block-service": "0.15.2",
+        "ipfs-repo": "0.25.0",
+        "ipld-dag-cbor": "0.13.0",
+        "ipld-dag-pb": "0.14.11",
+        "ipld-raw": "2.0.1",
+        "merge-options": "1.0.1",
+        "pull-defer": "0.2.3",
+        "pull-stream": "3.6.9",
+        "pull-traverse": "1.0.3"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        }
       }
     },
     "ipld-bitcoin": {
@@ -13876,6 +15024,31 @@
         "git-validate": "2.2.4",
         "multihashes": "0.4.14",
         "multihashing-async": "0.5.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        }
+      }
+    },
+    "ipld-dag-cbor": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.13.0.tgz",
+      "integrity": "sha512-74gtitUOWbLkGtqomhq7lDYwWzfFNwbwMXAj3jpti4ZtfM9VTJWVIQ+05u7NOCj8yaLwzFONHdcO0rJ+j/i0jA==",
+      "requires": {
+        "async": "2.6.1",
+        "borc": "2.0.4",
+        "bs58": "4.0.1",
+        "cids": "0.5.5",
+        "is-circular": "1.0.2",
+        "multihashes": "0.4.14",
+        "multihashing-async": "0.5.1",
+        "traverse": "0.6.6"
       },
       "dependencies": {
         "async": {
@@ -13916,19 +15089,19 @@
       }
     },
     "ipld-ethereum": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.1.tgz",
-      "integrity": "sha512-p+OIsTg7+NeXnE2Uq7g5HV7KVbJTQ9kVHSywOAUxUfj6loJb+6ReTCRrayQ+SbIXuVVVIVPU8OOUoGaugwFEjg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.2.tgz",
+      "integrity": "sha512-tKkoBL/Vg4rPJeZu4azbL8t/y6rcF2kfD5kMJ+J/r4Gu+cXkocN9i+A619/00jb+fonm2DgJOtMoSbBk5QfN0Q==",
       "requires": {
         "async": "2.6.1",
         "cids": "0.5.5",
         "ethereumjs-account": "2.0.5",
-        "ethereumjs-block": "1.7.1",
+        "ethereumjs-block": "2.1.0",
         "ethereumjs-tx": "1.3.7",
-        "ipfs-block": "0.6.1",
+        "ipfs-block": "0.8.0",
         "merkle-patricia-tree": "2.3.2",
         "multihashes": "0.4.14",
-        "multihashing-async": "0.4.8",
+        "multihashing-async": "0.5.1",
         "rlp": "2.1.0"
       },
       "dependencies": {
@@ -13938,27 +15111,6 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
             "lodash": "4.17.11"
-          }
-        },
-        "ipfs-block": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
-          "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
-          "requires": {
-            "cids": "0.5.5"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "2.6.1",
-            "blakejs": "1.1.0",
-            "js-sha3": "0.7.0",
-            "multihashes": "0.4.14",
-            "murmurhash3js": "3.0.1",
-            "nodeify": "1.0.1"
           }
         }
       }
@@ -14015,6 +15167,97 @@
           "requires": {
             "lodash": "4.17.11"
           }
+        }
+      }
+    },
+    "ipns": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.3.0.tgz",
+      "integrity": "sha512-3X8xS4AVgRbsqaTfpJ4OzqAJ2DOYXl9lh7AV/gq7qyF14A+YXk1zmCKc6xXS2GJSVkvsnoRsVGPRrQnDQoNksw==",
+      "requires": {
+        "base32-encode": "1.1.0",
+        "big.js": "5.2.2",
+        "debug": "3.1.0",
+        "interface-datastore": "0.6.0",
+        "left-pad": "1.3.0",
+        "libp2p-crypto": "0.13.0",
+        "multihashes": "0.4.14",
+        "nano-date": "2.1.0",
+        "peer-id": "0.11.0",
+        "protons": "1.0.1"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+          "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.1"
+          }
+        },
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        },
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
+        "libp2p-crypto": {
+          "version": "0.13.0",
+          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
+          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
+          "requires": {
+            "asn1.js": "5.0.1",
+            "async": "2.6.1",
+            "browserify-aes": "1.2.0",
+            "bs58": "4.0.1",
+            "keypair": "1.0.1",
+            "libp2p-crypto-secp256k1": "0.2.2",
+            "multihashing-async": "0.4.8",
+            "node-forge": "0.7.5",
+            "pem-jwk": "1.5.1",
+            "protons": "1.0.1",
+            "rsa-pem-to-jwk": "1.1.3",
+            "tweetnacl": "1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "requires": {
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.14",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
+          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
+          "requires": {
+            "async": "2.6.1",
+            "libp2p-crypto": "0.13.0",
+            "lodash": "4.17.11",
+            "multihashes": "0.4.14"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
         }
       }
     },
@@ -14271,6 +15514,14 @@
         "multihashes": "0.4.14"
       },
       "dependencies": {
+        "base-x": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
         "multibase": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.4.0.tgz",
@@ -14592,11 +15843,11 @@
       "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.1.3",
-        "@babel/parser": "7.1.3",
+        "@babel/generator": "7.1.5",
+        "@babel/parser": "7.1.5",
         "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3",
+        "@babel/traverse": "7.1.5",
+        "@babel/types": "7.1.5",
         "istanbul-lib-coverage": "2.0.1",
         "semver": "5.6.0"
       }
@@ -14738,9 +15989,9 @@
       }
     },
     "jsesc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -14882,7 +16133,7 @@
       "integrity": "sha512-NetT3wPCQMNB36uiL9LLyhrOt8SQwrEKt0xD3+KpTCfm0VxVyUJdPL5oTq2Ic5ouemgL/Iz4wqXEbF3zea9kQQ==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.2",
+        "bluebird": "3.5.3",
         "body-parser": "1.18.3",
         "chokidar": "2.0.4",
         "colors": "1.1.2",
@@ -15210,6 +16461,25 @@
         "xtend": "4.0.1"
       }
     },
+    "level-js": {
+      "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
+      "requires": {
+        "abstract-leveldown": "2.4.1",
+        "idb-readable-stream": "0.0.4",
+        "ltgt": "2.2.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.4.1",
+          "resolved": "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
+          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
     "level-ws": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
@@ -15314,6 +16584,16 @@
           "requires": {
             "end-of-stream": "1.4.1",
             "once": "1.4.0"
+          }
+        },
+        "simple-get": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+          "requires": {
+            "decompress-response": "3.3.0",
+            "once": "1.4.0",
+            "simple-concat": "1.0.0"
           }
         }
       }
@@ -15455,13 +16735,13 @@
           "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
           "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
           "requires": {
-            "hoek": "6.0.1"
+            "hoek": "6.0.2"
           },
           "dependencies": {
             "hoek": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.1.tgz",
-              "integrity": "sha512-3PvUwBerLNVJiIVQdpkWF9F/M0ekgb2NPJWOhsE28RXSQPsY42YSnaJ8d1kZjcAz58TZ/Fk9Tw64xJsENFlJNw=="
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.2.tgz",
+              "integrity": "sha512-0RGPLkyxpsMJVj/iOCaJaIWFEch988eUicJJpRiQ+Or1CMvBXcoZPlSx9FhreDWw4hxMYy8xgTEdlsYQDTnxWA=="
             }
           }
         },
@@ -15469,9 +16749,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -15554,9 +16831,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -15646,9 +16920,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -15678,7 +16949,7 @@
         "protons": "1.0.1",
         "rsa-pem-to-jwk": "1.1.3",
         "tweetnacl": "1.0.0",
-        "ursa-optional": "0.9.9",
+        "ursa-optional": "0.9.10",
         "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
       },
       "dependencies": {
@@ -15709,9 +16980,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -15821,9 +17089,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -15906,9 +17171,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -15926,7 +17188,7 @@
         "interface-datastore": "0.6.0",
         "k-bucket": "4.0.1",
         "libp2p-crypto": "0.13.0",
-        "libp2p-record": "0.6.0",
+        "libp2p-record": "0.6.1",
         "multihashes": "0.4.14",
         "multihashing-async": "0.5.1",
         "peer-id": "0.11.0",
@@ -16007,9 +17269,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -16081,9 +17340,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -16217,16 +17473,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
     "libp2p-mplex": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.8.2.tgz",
-      "integrity": "sha512-tQTNyjSlEhLXHaK2LYmNWdFNXkbmnrKI5gyGv9CaK43F1Zmo5AP6Ex18qSyXPBPyuOyJBLBI/kXiglik834+JA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.8.3.tgz",
+      "integrity": "sha512-/uDaFFRe4w2GKiG1QHhTimESVj5S0N47aBOOfelEm52SkYM1Q07N2sb+YDU1GBUHmcojxC3W9dWj5rwJaytjhQ==",
       "requires": {
         "async": "2.6.1",
         "chunky": "0.0.0",
@@ -16240,7 +17493,7 @@
         "pump": "3.0.0",
         "readable-stream": "3.0.6",
         "stream-to-pull-stream": "1.7.2",
-        "through2": "2.0.3",
+        "through2": "2.0.5",
         "varint": "5.0.0"
       },
       "dependencies": {
@@ -16275,12 +17528,13 @@
       }
     },
     "libp2p-record": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.6.0.tgz",
-      "integrity": "sha512-0hAAkyU4jyJoktUserbbg5OVwt+leXIyPsfdoJCbUrVnj1jLMZz5OG38qxSacyqmsZ4iln6D7ttIjZZPwaOp1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.6.1.tgz",
+      "integrity": "sha512-GUZ0kQTHFpxeljJhW5f1PnmwW2A0qU9NmF3TP4xkZDmJs3HqawrYovVr9ROGNEPI4ovwjZkJSuG+an3QCQxXWA==",
       "requires": {
         "async": "2.6.1",
         "buffer-split": "1.0.0",
+        "err-code": "1.1.2",
         "left-pad": "1.3.0",
         "multihashes": "0.4.14",
         "multihashing-async": "0.4.8",
@@ -16446,10 +17700,24 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
+      }
+    },
+    "libp2p-tcp": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.13.0.tgz",
+      "integrity": "sha512-bsmfxi+uVegK61x9UxBEgWtvujPl+zwzuVEyaVRs2IxHu6OE5MGKnj7AflzlK4e3w2HZn8nm4qwMV5m+fhqK1g==",
+      "requires": {
+        "class-is": "1.1.0",
+        "debug": "3.1.0",
+        "interface-connection": "0.3.2",
+        "ip-address": "5.8.9",
+        "lodash.includes": "4.3.0",
+        "lodash.isfunction": "3.0.9",
+        "mafmt": "6.0.2",
+        "multiaddr": "5.0.2",
+        "once": "1.4.0",
+        "stream-to-pull-stream": "1.7.2"
       }
     },
     "libp2p-webrtc-star": {
@@ -16550,12 +17818,100 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        }
+      }
+    },
+    "libp2p-websocket-star": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.9.0.tgz",
+      "integrity": "sha512-1moYa1geS0Tj0w9bTNngnnC6dE3wm0EiLRr0A60RLoOI7OrkxoLGBbPCA1m5f5OCXlCXZae7RgP2Yo9Qfj42mQ==",
+      "requires": {
+        "async": "2.6.1",
+        "class-is": "1.1.0",
+        "data-queue": "0.0.3",
+        "debug": "3.1.0",
+        "interface-connection": "0.3.2",
+        "libp2p-crypto": "0.14.1",
+        "mafmt": "6.0.2",
+        "merge-recursive": "0.0.3",
+        "multiaddr": "5.0.2",
+        "once": "1.4.0",
+        "peer-id": "0.11.0",
+        "peer-info": "0.14.1",
+        "pull-stream": "3.6.9",
+        "socket.io-client": "2.1.1",
+        "socket.io-pull-stream": "0.1.5",
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+          "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.1"
+          }
         },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
         },
-        "webrtcsupport": {
-          "version": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "requires": {
+            "async": "2.6.1",
+            "blakejs": "1.1.0",
+            "js-sha3": "0.7.0",
+            "multihashes": "0.4.14",
+            "murmurhash3js": "3.0.1",
+            "nodeify": "1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
+          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
+          "requires": {
+            "async": "2.6.1",
+            "libp2p-crypto": "0.13.0",
+            "lodash": "4.17.11",
+            "multihashes": "0.4.14"
+          },
+          "dependencies": {
+            "libp2p-crypto": {
+              "version": "0.13.0",
+              "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
+              "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
+              "requires": {
+                "asn1.js": "5.0.1",
+                "async": "2.6.1",
+                "browserify-aes": "1.2.0",
+                "bs58": "4.0.1",
+                "keypair": "1.0.1",
+                "libp2p-crypto-secp256k1": "0.2.2",
+                "multihashing-async": "0.4.8",
+                "node-forge": "0.7.5",
+                "pem-jwk": "1.5.1",
+                "protons": "1.0.1",
+                "rsa-pem-to-jwk": "1.1.3",
+                "tweetnacl": "1.0.0",
+                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+              }
+            }
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
         }
       }
     },
@@ -16846,13 +18202,6 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
             "lodash": "4.17.11"
-          }
-        },
-        "fs-ext": {
-          "version": "github:baudehlo/node-fs-ext#2ba366d9fc67ef3ab165e239068924b276ecf249",
-          "optional": true,
-          "requires": {
-            "nan": "2.11.1"
           }
         }
       }
@@ -17317,6 +18666,11 @@
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
+    "map-or-similar": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
+      "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg="
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -17416,9 +18770,9 @@
       }
     },
     "mdast-util-to-hast": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.2.tgz",
-      "integrity": "sha512-YI8Ea3TFWEZrS31+6Q/d8ZYTOSDKM06IPc3l2+OMFX1o3JTG2mrztlmzDsUMwIXLWofEdTVl/WXBgRG6ddlU/A==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz",
+      "integrity": "sha512-/eIbly2YmyVgpJNo+bFLLMCI1XgolO/Ffowhf+pHDq3X4/V6FntC9sGQCDLM147eTS+uSXv5dRzJyFn+o0tazA==",
       "dev": true,
       "requires": {
         "collapse-white-space": "1.0.4",
@@ -17496,6 +18850,14 @@
             "xtend": "4.0.1"
           }
         }
+      }
+    },
+    "memoizerific": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
+      "integrity": "sha1-fIekZGREwy11Q4VwkF8tvRsagFo=",
+      "requires": {
+        "map-or-similar": "1.5.0"
       }
     },
     "memory-fs": {
@@ -17578,6 +18940,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
     },
     "merge-recursive": {
       "version": "0.0.3",
@@ -17899,7 +19269,7 @@
         "pump": "3.0.0",
         "pumpify": "1.5.1",
         "stream-each": "1.2.3",
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       }
     },
     "mitt": {
@@ -18046,7 +19416,7 @@
         "resolve": "1.8.1",
         "stream-combiner2": "1.1.1",
         "subarg": "1.0.0",
-        "through2": "2.0.3",
+        "through2": "2.0.5",
         "xtend": "4.0.1"
       },
       "dependencies": {
@@ -18159,6 +19529,16 @@
       "integrity": "sha512-7epKiK8/UBzraYZvOuZa8FH/00hMfTnzTy1OQol1YBU2csAYA7rwWh+iue9plXRmVFBGvmVKMuo0oq5sD47kvw==",
       "requires": {
         "base-x": "3.0.4"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        }
       }
     },
     "multicast-dns": {
@@ -18263,6 +19643,23 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
       "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
     },
+    "nano-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nano-date/-/nano-date-2.1.0.tgz",
+      "integrity": "sha1-veghPYoPKtGjoW6PRV7uJHX/2/k=",
+      "requires": {
+        "bignumber.js": "4.1.0",
+        "core-decorators": "0.20.0",
+        "memoizerific": "1.11.3"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+          "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
+        }
+      }
+    },
     "nanoid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.0.tgz",
@@ -18319,7 +19716,7 @@
         "json-stringify-safe": "5.0.1",
         "minimist": "1.2.0",
         "split2": "2.2.0",
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       },
       "dependencies": {
         "minimist": {
@@ -20022,7 +21419,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -20053,7 +21450,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "output-file-sync": {
@@ -20467,7 +21864,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -20618,9 +22015,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -20691,9 +22085,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -20789,9 +22180,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-        },
-        "webcrypto-shim": {
-          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -20895,8 +22283,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83"
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84"
           }
         }
       }
@@ -21190,8 +22578,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
           "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83",
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84",
             "node-releases": "1.0.3"
           }
         },
@@ -21352,7 +22740,7 @@
           "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
           "requires": {
             "browserslist": "2.11.3",
-            "caniuse-lite": "1.0.30000905",
+            "caniuse-lite": "1.0.30000907",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "6.0.23",
@@ -21364,8 +22752,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83"
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84"
           }
         },
         "caniuse-api": {
@@ -21374,7 +22762,7 @@
           "integrity": "sha1-sd21pZZrFvSNxJmERNS7xsfZ2DQ=",
           "requires": {
             "browserslist": "2.11.3",
-            "caniuse-lite": "1.0.30000905",
+            "caniuse-lite": "1.0.30000907",
             "lodash.memoize": "4.1.2",
             "lodash.uniq": "4.5.0"
           }
@@ -21749,7 +23137,7 @@
       "integrity": "sha512-AU2/9QDmHYJRxTiniMt2bJ9fwCzVF6n00VnR4gdnFGHeXRW2mGwoptpuPgYjfivkdI8LlNIuo+w8TyS6a4JhJw==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.1.2",
+        "@babel/core": "7.1.5",
         "postcss-styled": "0.34.0"
       }
     },
@@ -21883,8 +23271,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
           "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83",
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84",
             "node-releases": "1.0.3"
           }
         },
@@ -21992,8 +23380,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
           "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83",
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84",
             "node-releases": "1.0.3"
           }
         },
@@ -22362,8 +23750,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
           "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83",
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84",
             "node-releases": "1.0.3"
           }
         },
@@ -22525,8 +23913,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
           "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83",
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84",
             "node-releases": "1.0.3"
           }
         },
@@ -22941,16 +24329,16 @@
       }
     },
     "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-      "optional": true,
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.1.tgz",
+      "integrity": "sha512-9DAccsInWHB48TBQi2eJkLPE049JuAI6FjIH0oIrij4bpDVEbX6JvlWRAcAAlUqBHhjgq0jNqA3m3bBXWm9v6w==",
       "requires": {
         "detect-libc": "1.0.3",
         "expand-template": "1.1.1",
         "github-from-package": "0.0.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
+        "napi-build-utils": "1.0.1",
         "node-abi": "2.5.0",
         "noop-logger": "0.1.1",
         "npmlog": "4.1.2",
@@ -22966,17 +24354,25 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "optional": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "pump": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "optional": true,
           "requires": {
             "end-of-stream": "1.4.1",
             "once": "1.4.0"
+          }
+        },
+        "simple-get": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+          "requires": {
+            "decompress-response": "3.3.0",
+            "once": "1.4.0",
+            "simple-concat": "1.0.0"
           }
         }
       }
@@ -23002,9 +24398,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
-      "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg=="
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.1.tgz",
+      "integrity": "sha512-4rgV2hyc/5Pk0XHH4VjJWHRgVjgRbpMfLQjREAhHBtyW1UvTFkjJEsueGYNYYZd9mn97K+1qv0EBwm11zoaSgA=="
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -23061,6 +24457,16 @@
       "optional": true,
       "requires": {
         "tdigest": "0.1.1"
+      }
+    },
+    "prometheus-gc-stats": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.0.tgz",
+      "integrity": "sha512-4kC+sGrSYT653/gDrnoeEISuM9wueSy524xvGzKpHA6Xf6xgTL5cpOxgBmrOyRDv8VvJPZ6lLTcRlBfmvOoeUw==",
+      "optional": true,
+      "requires": {
+        "gc-stats": "1.2.0",
+        "optional": "0.1.4"
       }
     },
     "promise": {
@@ -23501,16 +24907,6 @@
         "readable-stream": "2.3.6"
       },
       "dependencies": {
-        "bl": {
-          "version": "1.2.2",
-          "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-          "optional": true,
-          "requires": {
-            "readable-stream": "2.3.6",
-            "safe-buffer": "5.1.2"
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -23523,8 +24919,51 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "optional": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "prebuild-install": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
+          "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.1",
+            "github-from-package": "0.0.0",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.5.0",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.8",
+            "simple-get": "2.8.1",
+            "tar-fs": "1.16.3",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
+          }
+        },
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "optional": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        },
+        "simple-get": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+          "optional": true,
+          "requires": {
+            "decompress-response": "3.3.0",
+            "once": "1.4.0",
+            "simple-concat": "1.0.0"
+          }
         }
       }
     },
@@ -23635,14 +25074,14 @@
       }
     },
     "react": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.6.0.tgz",
-      "integrity": "sha512-zJPnx/jKtuOEXCbQ9BKaxDMxR0001/hzxXwYxG8septeyYGfsgAei6NgfbVgOhbY1WOP2o3VPs/E9HaN+9hV3Q==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.6.1.tgz",
+      "integrity": "sha512-OtawJThYlvRgm9BXK+xTL7BIlDx8vv21j+fbQDjRRUyok6y7NyjlweGorielTahLZHYIdKUoK2Dp9ByVWuMqxw==",
       "requires": {
         "loose-envify": "1.4.0",
         "object-assign": "4.1.1",
         "prop-types": "15.6.2",
-        "scheduler": "0.10.0"
+        "scheduler": "0.11.0"
       }
     },
     "react-dev-utils": {
@@ -23720,14 +25159,14 @@
       }
     },
     "react-dom": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.0.tgz",
-      "integrity": "sha512-Stm2D9dXEUUAQdvpvhvFj/DEXwC2PAL/RwEMhoN4dvvD2ikTlJegEXf97xryg88VIAU22ZAP7n842l+9BTz6+w==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.1.tgz",
+      "integrity": "sha512-zm+wBuEMGm009Wt1uE4Zw5KcXOW7qC4E/xW/fpJsCsbOco4U/R84u+DzzO/S4SYSdNBcqcaulcp4w3FXl8pImw==",
       "requires": {
         "loose-envify": "1.4.0",
         "object-assign": "4.1.1",
         "prop-types": "15.6.2",
-        "scheduler": "0.10.0"
+        "scheduler": "0.11.0"
       }
     },
     "react-error-overlay": {
@@ -23884,14 +25323,14 @@
         "enquire.js": "2.1.6",
         "json2mq": "0.2.0",
         "lodash.debounce": "4.0.8",
-        "prettier": "1.14.3",
+        "prettier": "1.15.1",
         "resize-observer-polyfill": "1.5.0"
       }
     },
     "react-toastify": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-4.4.0.tgz",
-      "integrity": "sha512-nTp084SO1rapKggtiWKpN2DE/wgWpJRT3OqAjpi52CeymhybA0IElmWWdqg1sUCBV1lFb4LlmPUIe5XrVz8q0g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-4.4.1.tgz",
+      "integrity": "sha512-m/1oZXy+oT5wkRS+P/8v7q/9L/2KJIeRZOLiMXuOHdZf92RWf468WEzeq3Ymf2miHjvQ7rHv23hE9nhgPf1AZA==",
       "requires": {
         "classnames": "2.2.6",
         "prop-types": "15.6.2",
@@ -24005,6 +25444,21 @@
         "graceful-fs": "4.1.15",
         "micromatch": "3.1.10",
         "readable-stream": "2.3.6"
+      }
+    },
+    "receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "requires": {
+        "ms": "2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "rechoir": {
@@ -24185,7 +25639,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -24326,9 +25780,9 @@
       "integrity": "sha512-jqRzkZXCkM12gIY2ibMLTW41m7rfanliMTVQCFTezHJFsbH00YaTox/BX4gU+f/zCdzfhFJONtebFByvpMv37w==",
       "dev": true,
       "requires": {
-        "hast-util-sanitize": "1.2.0",
+        "hast-util-sanitize": "1.2.1",
         "hast-util-to-html": "3.1.0",
-        "mdast-util-to-hast": "3.0.2",
+        "mdast-util-to-hast": "3.0.4",
         "xtend": "4.0.1"
       }
     },
@@ -24438,7 +25892,7 @@
       "requires": {
         "remove-bom-buffer": "3.0.0",
         "safe-buffer": "5.1.2",
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       }
     },
     "remove-trailing-separator": {
@@ -24531,11 +25985,31 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
+      },
+      "dependencies": {
+        "caller-path": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+          "requires": {
+            "callsites": "0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+        }
       }
     },
     "requires-port": {
@@ -24571,13 +26045,6 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
         "resolve-from": "3.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-        }
       }
     },
     "resolve-dir": {
@@ -24590,9 +26057,9 @@
       }
     },
     "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
     "resolve-global": {
       "version": "0.1.0",
@@ -24844,9 +26311,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.10.0.tgz",
-      "integrity": "sha512-+TSTVTCBAA3h8Anei3haDc1IRwMeDmtI/y/o3iBe3Mjl2vwYF9DtPDt929HyRmV/e7au7CLu8sc4C4W0VOs29w==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.0.tgz",
+      "integrity": "sha512-MAYbBfmiEHxF0W+c4CxMpEqMYK+rYF584VP/qMKSiHM6lTkBKKYOJaDiSILpJHla6hBOsVd6GucPL46o2Uq3sg==",
       "requires": {
         "loose-envify": "1.4.0",
         "object-assign": "4.1.1"
@@ -25064,14 +26531,6 @@
         "webcrypto-shim": "0.1.4"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.4.1",
-          "resolved": "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
-          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
         "asn1.js": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
@@ -25090,10 +26549,27 @@
             "lodash": "4.17.11"
           }
         },
+        "base-x": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
         "big.js": {
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
           "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
+        "bl": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.1.2.tgz",
+          "integrity": "sha512-DvC0x+PxmSJNx8wXoFV15pC2+GOJ3ohb4F1REq3X32a2Z3nEBpR1Guu740M7ouYAImFj4BXDNilLNZbygtG9lQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "safe-buffer": "5.1.2"
+          }
         },
         "cross-spawn": {
           "version": "6.0.5",
@@ -25169,6 +26645,11 @@
             "signal-exit": "3.0.2",
             "strip-eof": "1.0.0"
           }
+        },
+        "file-type": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
         },
         "filesize": {
           "version": "3.6.1",
@@ -25257,7 +26738,7 @@
             "libp2p-kad-dht": "0.10.6",
             "libp2p-keychain": "0.3.3",
             "libp2p-mdns": "0.12.0",
-            "libp2p-mplex": "0.8.2",
+            "libp2p-mplex": "0.8.3",
             "libp2p-secio": "0.10.1",
             "libp2p-tcp": "0.12.1",
             "libp2p-webrtc-star": "0.15.5",
@@ -25295,7 +26776,7 @@
             "stream-to-pull-stream": "1.7.2",
             "tar-stream": "1.6.2",
             "temp": "0.8.3",
-            "through2": "2.0.3",
+            "through2": "2.0.5",
             "update-notifier": "2.5.0",
             "yargs": "12.0.2",
             "yargs-parser": "10.1.0",
@@ -25375,10 +26856,37 @@
             "varint-decoder": "0.1.1"
           }
         },
+        "ipfs-block": {
+          "version": "0.7.1",
+          "resolved": "http://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
+          "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
+          "requires": {
+            "cids": "0.5.5",
+            "class-is": "1.1.0"
+          }
+        },
         "ipfs-block-service": {
           "version": "0.14.0",
           "resolved": "http://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.14.0.tgz",
           "integrity": "sha512-qu5VdBSAh/44wtqVgyoyWebjIY6mLbiEZObwYZHEZ5VFuU4oOlfZ+s2oz2I5lTw1eeL7SGccQeshQ0OePxIPnw=="
+        },
+        "ipfs-http-response": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.1.4.tgz",
+          "integrity": "sha512-qVi0AK3evZBbHljePgmeFy6o8RBVTOmPXUgRNHrwFr99DmJHPhbgJ/Wse0vpQsKwo3dd1m7RP33GHE9Xd1vmPA==",
+          "requires": {
+            "async": "2.6.1",
+            "cids": "0.5.5",
+            "debug": "3.1.0",
+            "file-type": "8.1.0",
+            "filesize": "3.6.1",
+            "get-stream": "3.0.0",
+            "ipfs-unixfs": "0.1.16",
+            "mime-types": "2.1.21",
+            "multihashes": "0.4.14",
+            "promisify-es6": "1.0.3",
+            "stream-to-blob": "1.0.1"
+          }
         },
         "ipfs-mfs": {
           "version": "0.3.3",
@@ -25494,7 +27002,7 @@
             "ipld-bitcoin": "0.1.8",
             "ipld-dag-cbor": "0.12.1",
             "ipld-dag-pb": "0.14.11",
-            "ipld-ethereum": "2.0.1",
+            "ipld-ethereum": "2.0.2",
             "ipld-git": "0.2.2",
             "ipld-raw": "2.0.1",
             "ipld-zcash": "0.1.6",
@@ -25634,15 +27142,6 @@
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "requires": {
             "invert-kv": "2.0.0"
-          }
-        },
-        "level-js": {
-          "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
-          "requires": {
-            "abstract-leveldown": "2.4.1",
-            "idb-readable-stream": "0.0.4",
-            "ltgt": "2.2.1",
-            "xtend": "4.0.1"
           }
         },
         "libp2p-crypto": {
@@ -25841,16 +27340,6 @@
             "inherits": "2.0.3",
             "ltgt": "2.2.1",
             "safe-buffer": "5.1.2"
-          },
-          "dependencies": {
-            "abstract-leveldown": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-              "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-              "requires": {
-                "xtend": "4.0.1"
-              }
-            }
           }
         },
         "multibase": {
@@ -25945,13 +27434,13 @@
           "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
           "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
           "requires": {
-            "hoek": "6.0.1"
+            "hoek": "6.0.2"
           },
           "dependencies": {
             "hoek": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.1.tgz",
-              "integrity": "sha512-3PvUwBerLNVJiIVQdpkWF9F/M0ekgb2NPJWOhsE28RXSQPsY42YSnaJ8d1kZjcAz58TZ/Fk9Tw64xJsENFlJNw=="
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.2.tgz",
+              "integrity": "sha512-0RGPLkyxpsMJVj/iOCaJaIWFEch988eUicJJpRiQ+Or1CMvBXcoZPlSx9FhreDWw4hxMYy8xgTEdlsYQDTnxWA=="
             }
           }
         },
@@ -25959,6 +27448,11 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.4.tgz",
+          "integrity": "sha512-I2lnL+K2oPNE9ryVHwo42oDnt8XQ9E1KKMGCmcT7OXaAKPmUeCi/G0nUgLR6M6Ztj05ZCxLMGf5bXNaSo+wURg=="
         },
         "yargs": {
           "version": "12.0.2",
@@ -26066,69 +27560,8 @@
         "prebuild-install": "5.2.1",
         "semver": "5.6.0",
         "simple-get": "3.0.3",
-        "tar": "4.4.7",
+        "tar": "4.4.8",
         "tunnel-agent": "0.6.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "prebuild-install": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.1.tgz",
-          "integrity": "sha512-9DAccsInWHB48TBQi2eJkLPE049JuAI6FjIH0oIrij4bpDVEbX6JvlWRAcAAlUqBHhjgq0jNqA3m3bBXWm9v6w==",
-          "requires": {
-            "detect-libc": "1.0.3",
-            "expand-template": "1.1.1",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "napi-build-utils": "1.0.1",
-            "node-abi": "2.5.0",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "2.0.1",
-            "rc": "1.2.8",
-            "simple-get": "2.8.1",
-            "tar-fs": "1.16.3",
-            "tunnel-agent": "0.6.0",
-            "which-pm-runs": "1.0.0"
-          },
-          "dependencies": {
-            "simple-get": {
-              "version": "2.8.1",
-              "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-              "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-              "requires": {
-                "decompress-response": "3.3.0",
-                "once": "1.4.0",
-                "simple-concat": "1.0.0"
-              }
-            }
-          }
-        },
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
-          }
-        },
-        "simple-get": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.0.3.tgz",
-          "integrity": "sha512-Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==",
-          "requires": {
-            "decompress-response": "3.3.0",
-            "once": "1.4.0",
-            "simple-concat": "1.0.0"
-          }
-        }
       }
     },
     "shebang-command": {
@@ -26230,9 +27663,9 @@
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
     "simple-get": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.0.3.tgz",
+      "integrity": "sha512-Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==",
       "requires": {
         "decompress-response": "3.3.0",
         "once": "1.4.0",
@@ -26461,7 +27894,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "requires": {
         "component-emitter": "1.2.1",
@@ -26709,7 +28142,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "requires": {
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       }
     },
     "sprintf-js": {
@@ -27137,8 +28570,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
           "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83",
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84",
             "node-releases": "1.0.3"
           }
         },
@@ -27178,7 +28611,7 @@
         "autoprefixer": "9.3.1",
         "balanced-match": "1.0.0",
         "chalk": "2.4.1",
-        "cosmiconfig": "5.0.6",
+        "cosmiconfig": "5.0.7",
         "debug": "4.1.0",
         "execall": "1.0.0",
         "file-entry-cache": "2.0.0",
@@ -27258,7 +28691,7 @@
           "dev": true,
           "requires": {
             "browserslist": "4.3.4",
-            "caniuse-lite": "1.0.30000905",
+            "caniuse-lite": "1.0.30000907",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "7.0.5",
@@ -27282,8 +28715,8 @@
           "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000905",
-            "electron-to-chromium": "1.3.83",
+            "caniuse-lite": "1.0.30000907",
+            "electron-to-chromium": "1.3.84",
             "node-releases": "1.0.3"
           }
         },
@@ -27848,9 +29281,9 @@
       "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA=="
     },
     "tar": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.7.tgz",
-      "integrity": "sha512-mR3MzsCdN0IEWjZRuF/J9gaWHnTwOvzjqPTcvi1xXgfKTDQRp39gRETPQEfPByAdEOGmZfx1HrRsn8estaEvtA==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "requires": {
         "chownr": "1.1.1",
         "fs-minipass": "1.2.5",
@@ -27902,17 +29335,6 @@
         "readable-stream": "2.3.6",
         "to-buffer": "1.1.1",
         "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "1.2.2",
-          "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-          "requires": {
-            "readable-stream": "2.3.6",
-            "safe-buffer": "5.1.2"
-          }
-        }
       }
     },
     "tdigest": {
@@ -27990,7 +29412,7 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.1.0.tgz",
       "integrity": "sha512-61lV0DSxMAZ8AyZG7/A4a3UPlrbOBo8NIQ4tJzLPAdGOQ+yoNC7l5ijEow27lBAL2humer01KLS6bGIMYQxKoA==",
       "requires": {
-        "cacache": "11.3.0",
+        "cacache": "11.3.1",
         "find-cache-dir": "2.0.0",
         "schema-utils": "1.0.0",
         "serialize-javascript": "1.5.0",
@@ -28115,9 +29537,9 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "requires": {
         "readable-stream": "2.3.6",
         "xtend": "4.0.1"
@@ -28129,7 +29551,7 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3",
+        "through2": "2.0.5",
         "xtend": "4.0.1"
       }
     },
@@ -28287,7 +29709,7 @@
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "2.0.5"
       }
     },
     "topo": {
@@ -28510,7 +29932,7 @@
           "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
           "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
           "requires": {
-            "bluebird": "3.5.2",
+            "bluebird": "3.5.3",
             "chownr": "1.1.1",
             "glob": "7.1.3",
             "graceful-fs": "4.1.15",
@@ -28548,7 +29970,7 @@
             "pump": "2.0.1",
             "pumpify": "1.5.1",
             "stream-each": "1.2.3",
-            "through2": "2.0.3"
+            "through2": "2.0.5"
           }
         },
         "pump": {
@@ -28998,13 +30420,12 @@
       "dev": true
     },
     "ursa-optional": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.9.tgz",
-      "integrity": "sha512-zEXexF6kK+MXbPO4PCSNZXD1bQNImKDkTVgGLFTMO7hvfbEmX4s6KwXla6VZm4eFua7hUiEH+gqsx11+ryYLpg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz",
+      "integrity": "sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==",
       "requires": {
         "bindings": "1.3.0",
-        "nan": "2.11.1",
-        "which": "1.3.1"
+        "nan": "2.11.1"
       }
     },
     "use": {
@@ -29271,7 +30692,7 @@
         "readable-stream": "2.3.6",
         "strip-bom": "2.0.0",
         "strip-bom-stream": "1.0.0",
-        "through2": "2.0.3",
+        "through2": "2.0.5",
         "through2-filter": "2.0.0",
         "vali-date": "1.0.0",
         "vinyl": "1.2.0"
@@ -29379,7 +30800,7 @@
             },
             "through2": {
               "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
               "requires": {
@@ -29578,9 +30999,7 @@
       }
     },
     "webcrypto-shim": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.4.tgz",
-      "integrity": "sha512-I2lnL+K2oPNE9ryVHwo42oDnt8XQ9E1KKMGCmcT7OXaAKPmUeCi/G0nUgLR6M6Ztj05ZCxLMGf5bXNaSo+wURg=="
+      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
     },
     "webidl-conversions": {
       "version": "2.0.1",
@@ -29590,9 +31009,9 @@
       "optional": true
     },
     "webpack": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.25.0.tgz",
-      "integrity": "sha512-ppUNnCL9kSH7e74fro88cdT1Lfzjw8Nmx5ue8ZJimGZOvlausKBNOc0EiI1DrVKmydnLRA3FzBHoEGdpVXpiHA==",
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.25.1.tgz",
+      "integrity": "sha512-T0GU/3NRtO4tMfNzsvpdhUr8HnzA4LTdP2zd+e5zd6CdOH5vNKHnAlO+DvzccfhPdzqRrALOFcjYxx7K5DWmvA==",
       "requires": {
         "@webassemblyjs/ast": "1.7.11",
         "@webassemblyjs/helper-module-context": "1.7.11",
@@ -29658,48 +31077,40 @@
       }
     },
     "webpack-bundle-analyzer": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.3.tgz",
-      "integrity": "sha512-naLWiRfmtH4UJgtUktRTLw6FdoZJ2RvCR9ePbwM9aRMsS/KjFerkPZG9epEvXRAw5d5oPdrs9+3p+afNjxW8Xw==",
-      "dev": true,
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.13.1.tgz",
+      "integrity": "sha512-rwxyfecTAxoarCC9VlHlIpfQCmmJ/qWD5bpbjkof+7HrNhTNZIwZITxN6CdlYL2axGmwNUQ+tFgcSOiNXMf/sQ==",
       "requires": {
         "acorn": "5.7.3",
-        "bfj": "6.1.1",
+        "bfj-node4": "5.3.1",
         "chalk": "2.4.1",
         "commander": "2.19.0",
         "ejs": "2.6.1",
         "express": "4.16.4",
-        "filesize": "3.6.1",
-        "gzip-size": "5.0.0",
+        "filesize": "3.5.11",
+        "gzip-size": "4.1.0",
         "lodash": "4.17.11",
         "mkdirp": "0.5.1",
         "opener": "1.5.1",
-        "ws": "6.1.0"
+        "ws": "4.1.0"
       },
       "dependencies": {
-        "filesize": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-          "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
-          "dev": true
-        },
         "gzip-size": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
-          "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
-          "dev": true,
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.1.0.tgz",
+          "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
           "requires": {
             "duplexer": "0.1.1",
             "pify": "3.0.0"
           }
         },
         "ws": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.0.tgz",
-          "integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
-          "dev": true,
+          "version": "4.1.0",
+          "resolved": "http://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
           "requires": {
-            "async-limiter": "1.0.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -30176,6 +31587,9 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-0.1.5.tgz",
       "integrity": "sha1-KeXxLr/VMVjTHWVqETrB97hhedk="
+    },
+    "webrtcsupport": {
+      "version": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
     },
     "websocket-driver": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gatsby-plugin-react-helmet": "^3.0.1",
     "gatsby-plugin-webpack-bundle-analyzer": "^1.0.3",
     "intersection-observer": "~0.5.0",
+    "ipfs": "~0.33.1",
     "normalize.css": "^8.0.0",
     "postcss-import": "^12.0.0",
     "postcss-preset-moxy": "^2.3.1",

--- a/src/shared/utils/react-live.js
+++ b/src/shared/utils/react-live.js
@@ -59,20 +59,17 @@ function stubIpfs (node) {
 
 function getIpfs (opts) {
   return new Promise((resolve, reject) => {
-    const onLoad = () => {
-      const Ipfs = window.Ipfs
-      const node = new Ipfs({ repo: 'getting-started' })
-      node.once('ready', () => {
-        resolve(stubIpfs(node, Ipfs), node, Ipfs)
+    // We are using webpackChunkName in the comment so that our chunk
+    // will be named `ipfs.[hash].js` instead of `[id].[hash].js`
+    import(/* webpackChunkName: "ipfs" */ 'ipfs')
+      .then(({ default: Ipfs }) => {
+        const node = new Ipfs({ repo: 'getting-started' })
+        node.once('ready', () => {
+          resolve(stubIpfs(node, Ipfs), node, Ipfs)
+        })
+        node.on('error', (err) => reject(err))
       })
-    }
-
-    var script = document.createElement('script')
-    script.src = 'https://unpkg.com/ipfs/dist/index.min.js'
-    script.defer = true
-    script.onload = onLoad
-    script.onerror = reject
-    document.body.appendChild(script)
+      .catch((err) => reject(err))
   })
 }
 


### PR DESCRIPTION
This PR removes the use of [unpkg](https://github.com/unpkg) to load `ipfs`. 
`ipfs` was added as a dependency and it is bundled on separate chunks.

Closes #152.

