### PR TITLE
fix: husky not overriding existing hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1939,9 +1939,9 @@
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
     },
     "aegir": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/aegir/-/aegir-17.1.0.tgz",
-      "integrity": "sha512-2CtYqi2ASc7j+i4ycHPKuxBnJx6Wv/ZBKIHG2AYt4eQEI9ChcfJjc/5fjpGmOqug5bJG25ocs3bcNq2VdNbwNQ==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/aegir/-/aegir-17.1.1.tgz",
+      "integrity": "sha512-YYsF+Fvl8An+tz1Z1s+LG2gFMiuQ+iuUlYr4hggfEyLc7ALIwJWSe5cdoMP0h0pSnQbYXTPUDYnlv5s2HXehEw==",
       "dev": true,
       "requires": {
         "@babel/cli": "7.1.2",
@@ -1969,19 +1969,20 @@
         "detect-node": "^2.0.4",
         "documentation": "^9.0.0-alpha.1",
         "es6-promisify": "^6.0.1",
-        "eslint": "^4.19.0",
-        "eslint-config-standard": "^11.0.0",
+        "eslint": "^5.9.0",
+        "eslint-config-standard": "^12.0.0",
         "eslint-plugin-import": "^2.14.0",
-        "eslint-plugin-node": "^6.0.1",
-        "eslint-plugin-promise": "^3.8.0",
-        "eslint-plugin-standard": "^3.1.0",
+        "eslint-plugin-no-only-tests": "^2.0.1",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
         "execa": "^1.0.0",
         "filesize": "^3.6.1",
         "findup-sync": "^2.0.0",
         "fs-extra": "^7.0.0",
         "gh-pages": "^2.0.1",
         "git-validate": "^2.2.4",
-        "glob": "^7.1.3",
+        "globby": "^8.0.1",
         "joi": "^14.0.1",
         "json-loader": "~0.5.7",
         "karma": "^3.1.1",
@@ -2105,12 +2106,6 @@
             "regenerator-runtime": "^0.12.0"
           }
         },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "async": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
@@ -2137,50 +2132,17 @@
           "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
           "dev": true
         },
-        "eslint": {
-          "version": "4.19.1",
-          "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "ajv": "^5.3.0",
-            "babel-code-frame": "^6.22.0",
-            "chalk": "^2.1.0",
-            "concat-stream": "^1.6.0",
-            "cross-spawn": "^5.1.0",
-            "debug": "^3.1.0",
-            "doctrine": "^2.1.0",
-            "eslint-scope": "^3.7.1",
-            "eslint-visitor-keys": "^1.0.0",
-            "espree": "^3.5.4",
-            "esquery": "^1.0.0",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^2.0.0",
-            "functional-red-black-tree": "^1.0.1",
-            "glob": "^7.1.2",
-            "globals": "^11.0.1",
-            "ignore": "^3.3.3",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^3.0.6",
-            "is-resolvable": "^1.0.0",
-            "js-yaml": "^3.9.1",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.3.0",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.2",
-            "mkdirp": "^0.5.1",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.8.2",
-            "path-is-inside": "^1.0.2",
-            "pluralize": "^7.0.0",
-            "progress": "^2.0.0",
-            "regexpp": "^1.0.1",
-            "require-uncached": "^1.0.3",
-            "semver": "^5.3.0",
-            "strip-ansi": "^4.0.0",
-            "strip-json-comments": "~2.0.1",
-            "table": "4.0.2",
-            "text-table": "~0.2.0"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "execa": {
@@ -2196,21 +2158,6 @@
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "6.0.5",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-              "dev": true,
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            }
           }
         },
         "filesize": {
@@ -2246,6 +2193,29 @@
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
+          }
+        },
+        "globby": {
+          "version": "8.0.1",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
           }
         },
         "hoek": {
@@ -2347,19 +2317,6 @@
             "mem": "^4.0.0"
           },
           "dependencies": {
-            "cross-spawn": {
-              "version": "6.0.5",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-              "dev": true,
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            },
             "execa": {
               "version": "0.10.0",
               "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
@@ -2484,15 +2441,6 @@
             "inherits": "^2.0.1",
             "readable-stream": "^3.0.6",
             "xtend": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
           }
         },
         "topo": {
@@ -7392,7 +7340,7 @@
       "dependencies": {
         "color-convert": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
         }
       }
@@ -7425,7 +7373,7 @@
         },
         "color-string": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
           "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
           "requires": {
             "color-name": "^1.0.0"
@@ -10125,6 +10073,18 @@
             "semver": "5.3.0"
           }
         },
+        "eslint-plugin-promise": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
+          "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
+          "dev": true
+        },
+        "eslint-plugin-standard": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
+          "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
+          "dev": true
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -10142,9 +10102,9 @@
       }
     },
     "eslint-config-standard": {
-      "version": "11.0.0",
-      "resolved": "http://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
-      "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
+      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -10222,6 +10182,24 @@
         }
       }
     },
+    "eslint-plugin-es": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
+      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.1"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-flowtype": {
       "version": "2.50.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.3.tgz",
@@ -10290,22 +10268,38 @@
         "jsx-ast-utils": "^2.0.1"
       }
     },
+    "eslint-plugin-no-only-tests": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.0.1.tgz",
+      "integrity": "sha512-28FVGYJ+YZVaeKx+DTqI9gMlVIX2q0aWCIAWylBEyBjDINKVc0i/UJwzs6XmFZdy/T1kLjaRNr8IdSuTCFtChQ==",
+      "dev": true
+    },
     "eslint-plugin-node": {
-      "version": "6.0.1",
-      "resolved": "http://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
-      "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-8.0.0.tgz",
+      "integrity": "sha512-Y+ln8iQ52scz9+rSPnSWRaAxeWaoJZ4wIveDR0vLHkuSZGe44Vk1J4HX7WvEP5Cm+iXPE8ixo7OM7gAO3/OKpQ==",
       "dev": true,
       "requires": {
-        "ignore": "^3.3.6",
+        "eslint-plugin-es": "^1.3.1",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^5.0.2",
         "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
-        "semver": "^5.4.1"
+        "resolve": "^1.8.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.4.tgz",
+          "integrity": "sha512-WLsTMEhsQuXpCiG173+f3aymI43SXa+fB1rSfbzyP4GkPP+ZFVuO0/3sFUGNBtifisPeDcl/uD/Y2NxZ7xFq4g==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-promise": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
-      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
+      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
       "dev": true
     },
     "eslint-plugin-react": {
@@ -10321,9 +10315,9 @@
       }
     },
     "eslint-plugin-standard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
-      "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
+      "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
       "dev": true
     },
     "eslint-scope": {
@@ -14360,9 +14354,9 @@
       }
     },
     "hashlru": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.2.1.tgz",
-      "integrity": "sha1-EPIJmg18BaQPK+r1wdOc8vfavzY="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
     "hast-util-is-element": {
       "version": "1.0.2",
@@ -14906,6 +14900,11 @@
       "requires": {
         "postcss": "^6.0.1"
       }
+    },
+    "idb-keyval": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-3.1.0.tgz",
+      "integrity": "sha512-iFwFN5n00KNNnVxlOOK280SJJfXWY7pbMUOQXdIXehvvc/mGCV/6T2Ae+Pk2KwAkkATDTwfMavOiDH5lrJKWXQ=="
     },
     "idb-readable-stream": {
       "version": "0.0.4",
@@ -16844,13 +16843,13 @@
       }
     },
     "is-ipfs": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.4.7.tgz",
-      "integrity": "sha512-u+LzRRA5s2XMJnQ65R60SvRKb8R04ZITbbRMWBESLyLPlJ+J78zaXZzNZBIf4SQ0pnWioMNCpiIV4hw098MgOQ==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.4.8.tgz",
+      "integrity": "sha512-xIKUeA24IFMfkmeAPEOZL448X7a08c/KzAGQp1e/QxC9bx/NNEdT/ohob3SW6eJO2UwJNjsbfMeNZ2B+Dk2Fdg==",
       "requires": {
         "bs58": "4.0.1",
-        "cids": "~0.5.5",
-        "multibase": "~0.4.0",
+        "cids": "~0.5.6",
+        "multibase": "~0.6.0",
         "multihashes": "~0.4.13"
       },
       "dependencies": {
@@ -16863,9 +16862,9 @@
           }
         },
         "multibase": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.4.0.tgz",
-          "integrity": "sha512-fnYvZJWDn3eSJ7EeWvS8zbOpRwuyPHpDggSnqGXkQMvYED5NdO9nyqnZboGvAT+r/60J8KZ09tW8YJHkS22sFw==",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
+          "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
           "requires": {
             "base-x": "3.0.4"
           }
@@ -17255,7 +17254,7 @@
     },
     "joi-multiaddr": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-2.0.0.tgz",
       "integrity": "sha512-7dJLwgplwRnIQAlC+zTuX3jkk3uXVa/RKm7GDfNO3NqmjiYgwAet8yprIdilki1WhdkJJMLuTNDf49uFNru68A==",
       "requires": {
         "mafmt": "^6.0.0",
@@ -28129,15 +28128,16 @@
       }
     },
     "service-worker-gateway": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/service-worker-gateway/-/service-worker-gateway-0.1.8.tgz",
-      "integrity": "sha512-iJ4CIU+050PxR+eyLEWXxgChxO/S5/9C7KlBbjQIbk0sToD7mQL9hsokvUyhSJxs7JpjckVAq7Dxk/TVn6XJTA==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/service-worker-gateway/-/service-worker-gateway-0.1.9.tgz",
+      "integrity": "sha512-Q59qgJ8b/CxMfpC0C4WMZxOPgyBC7CjrBzbBqZcbnePfAemcd7pk2Cskq3yAZ/ibkt73xzu37WiSEj2Oqi4FHQ==",
       "requires": {
         "async": "^2.6.0",
         "cids": "~0.5.5",
         "debug": "^4.1.0",
         "file-type": "^10.5.0",
         "filesize": "^3.6.1",
+        "idb-keyval": "^3.0.5",
         "ipfs": "~0.33.1",
         "ipfs-http-response": "~0.2.1",
         "ipfs-postmsg-proxy": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "scripts": {
     "prebuild": "rimraf public",
+    "postinstall": "rimraf .git/hooks/* && node node_modules/husky/husky.js install",
     "develop": "gatsby develop",
     "build": "gatsby build --prefix-paths",
     "serve": "gatsby serve",


### PR DESCRIPTION
This PR fixes a problem related to [`husky`](https://www.npmjs.com/package/husky) which is: husky does not overwrite existing hooks.

To make it work, on `postinstall` script I'm currently deleting all the hooks using [`rimraf`](https://github.com/isaacs/rimraf) and then reinstall all the hooks.
So, `postbuild` script looks like:

```
"scripts": {
   (...),
   "postinstall": "rimraf .git/hooks/* && node node_modules/husky/husky.js install",
   (...)
}
```