### PR TITLE
feat: add gatsby-plugin-google-tag (gtag.js)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -36,6 +36,24 @@ module.exports = {
         analyzerPort: 3000,
         openAnalyzer: false
       }
+    },
+    {
+      resolve: 'gatsby-plugin-google-gtag',
+      options: {
+        trackingIds: [
+          'UA-96910779-5'
+        ],
+        gtagConfig: {
+          anonymize_ip: true,
+          cookie_name: 'gaCookie',
+          cookie_domain: 'js.ipfs.io',
+          cookie_expires: 0
+        },
+        pluginConfig: {
+          head: true,
+          respectDNT: true
+        }
+      }
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12418,6 +12418,15 @@
         "prop-types": "^15.6.1"
       }
     },
+    "gatsby-plugin-google-gtag": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-1.0.10.tgz",
+      "integrity": "sha512-5m1K+aScBQHt0hUYCv4Sdc610vpPIq+4gqlCbSvEnEs7jJSC+Pd/yEHKg8JtiuVjgny60Bc4GJPsE/u6RndPrg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "minimatch": "^3.0.4"
+      }
+    },
     "gatsby-plugin-ipfs": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-ipfs/-/gatsby-plugin-ipfs-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "axios": "~0.18.0",
     "classnames": "^2.2.6",
     "gatsby": "^2.0.0",
+    "gatsby-plugin-google-gtag": "^1.0.10",
     "gatsby-plugin-ipfs": "^2.0.2",
     "gatsby-plugin-layout": "^1.0.7",
     "gatsby-plugin-manifest": "^2.0.7",


### PR DESCRIPTION
This PR adds [gatsby-plugin-google-tag](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag) so that we can send event data to Google Analytics.