### PR TITLE
feat: include ipfs-camp ribbon

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -42,6 +42,9 @@ class Layout extends Component {
               { rel: 'icon', sizes: '32x32', href: withPrefix('/favicon/favicon-32x32.png'), type: 'image/png' },
               { rel: 'icon', sizes: '16x16', href: withPrefix('/favicon/favicon-16x16.png'), type: 'image/png' },
               { rel: 'mask-icon', href: withPrefix('/favicon/safari-pinned-tab.svg'), color: '#0a1732' }
+            ] }
+            script={ [
+              { src: 'https://camp.ipfs.io/ribbon.min.js', async: true }
             ] } >
           </Helmet>
 


### PR DESCRIPTION
This implements the IPFS Camp ribbon banner 💅

Currently only visible on larger screen layouts however I may also add a smaller screen variant once I've had chance to evaluate the analytics.

![ribbon-ipfs](https://user-images.githubusercontent.com/106938/56133912-63bb0200-5f85-11e9-877f-826342dcc565.jpg)

ref: protocol/2019-ipfs-camp#13