### PR TITLE
chore: update website hash

### DIFF
--- a/src/shared/constants/index.js
+++ b/src/shared/constants/index.js
@@ -1,6 +1,6 @@
 export const HASHES = {
   ipfsWebsite: 'QmYNQJoKGNHTpPxCBPh9KkDpaExgd2duMa3aF6ytMpHdao',
-  jsIpfsWebsite: 'QmcckYa6Z3myL9Hz9d1vuRAmJheAgam8YQCaAyusUwxQFt',
+  jsIpfsWebsite: 'QmTfgXTG2PN15mQEo7VCbSfc8RbJd9stabBcE4hzKBuiMX',
   awesomeIpfsWebsite: 'Qmcwy9pCEeyhj7rwSRtoAHVDskWpTumjbgLSBsS24PMY54',
   peerpadWebsite: 'QmXRTzu4dUFnA1nLR7ogifE1EeY2hEsVyQNkZu4CzF6g2v'
 }


### PR DESCRIPTION
This PR updates [js.ipfs.io](https://js.ipfs.io/) hash to `QmTfgXTG2PN15mQEo7VCbSfc8RbJd9stabBcE4hzKBuiMX`