### PR TITLE
chore: add protoschool link & fix libp2p references

### DIFF
--- a/intl/messages/en.json
+++ b/intl/messages/en.json
@@ -89,7 +89,7 @@
 
   "gettingStarted": {
     "sectionTitle": "Getting Started",
-    "sectionDesc": "IPFS gives you a Content Addressing primitive for all your data on the DWeb. You can make data available to the network or fetch existing data through its CID, the Content Identifier. Try it out below!",
+    "sectionDesc": "IPFS gives you a Content Addressing primitive for all your data on the DWeb. You can make data available to the network or fetch existing data through its CID, the Content Identifier. Try it out below or [explore our ProtoSchool tutorials](https://proto.school/#/tutorials)!",
     "addDataToIPFS": "Adding data to IPFS",
     "output": "Output",
     "getDataFromIPFS": "Getting data from IPFS",
@@ -141,8 +141,8 @@
     "sectionTitle": "What you can build with JS-IPFS",
     "sectionDesc": "There are unlimited options for you to use js-ipfs. The following examples provide you an idea of what you can build with js-ipfs. Try them out!",
     "suggestion": {
-      "text": "Do you have any idea and want to suggest?",
-      "linkText": "Do it here!"
+      "text": "Have suggestions?",
+      "linkText": "Share them here!"
     }
   },
 
@@ -153,7 +153,7 @@
 
   "community": {
     "sectionTitle": "Community",
-    "sectionDesc": "js-ipfs is an MIT Licensed, Open Source project from the IPFS community. There are many ways you can contribute: help write the specification, code implementations and tools using libp2p, craft examples and tutorials, and join our regular product calls to discuss libp2p with us.",
+    "sectionDesc": "js-ipfs is an MIT Licensed, Open Source project from the IPFS community. There are many ways you can contribute: help write the specification, code implementations and tools using js-ipfs, craft examples and tutorials, and join our working group calls to discuss IPFS with us.",
     "socialNetworksText": "Come hang out!"
   },
 

--- a/src/shared/components/getting-started-section/index.js
+++ b/src/shared/components/getting-started-section/index.js
@@ -10,6 +10,7 @@ import Svg from 'shared/components/svg'
 import Button from 'shared/components/button'
 import Link from 'shared/components/link'
 import SyntaxHighlighter from 'shared/components/syntax-highlighter'
+import ReactMarkdown from 'react-markdown'
 import {
   transformCode,
   log,
@@ -70,9 +71,7 @@ class GettingStarted extends Component {
         </div>
         <div className={ styles.content }>
           <h1>{ messages.gettingStarted.sectionTitle }</h1>
-          <span className={ styles.sectionDescription }>
-            <p>{ messages.gettingStarted.sectionDesc }</p>
-          </span>
+          <ReactMarkdown className={ styles.sectionDescription } source={ messages.gettingStarted.sectionDesc } />
           <div className={ styles.panel } >
             <p className={ styles.liveSnippetTitle }>{ messages.gettingStarted.addDataToIPFS }</p>
             <LiveProvider key="add" className={ styles.liveSnippet } code={ codeAdd } scope={ this.scopeAdd } mountStylesheet={ false } transformCode={ transformCode }>


### PR DESCRIPTION
Add link to ProtoSchool tutorials. 

Remove references to libp2p project and replace with IPFS. Was unable to add link to calls due to z-index issue to be addressed in later PR.

Paired w @fsdiogo @lidel 