### PR TITLE
docs: update examples to use strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1980,6 +1980,45 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
     "@stefanprobst/lokijs": {
       "version": "1.5.6-b",
       "resolved": "https://registry.npmjs.org/@stefanprobst/lokijs/-/lokijs-1.5.6-b.tgz",
@@ -3069,6 +3108,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+    },
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -3307,8 +3351,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -7333,7 +7376,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -9764,11 +9806,15 @@
         "rimraf": "^2.2.8"
       }
     },
+    "delay": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
+      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -12242,6 +12288,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
+      "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
+    },
     "fast-glob": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
@@ -12417,9 +12468,9 @@
       }
     },
     "file-type": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.2.0.tgz",
-      "integrity": "sha512-bkDBeH5doAqP69axEO69OviLlWbrZ10Ne2OPHaxBgG+fyT0w/2zfMzJz21SPwq5Iq0aN70q7RN3KRcdUY427Mg=="
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.3.1.tgz",
+      "integrity": "sha512-FXxY5h6vSYMjrRal4YqbtfuoKD/oE0AMjJ7E5Hm+BdaQECcFVD03B41RAWYJ7wyuLr/wRnCtFo7y37l+nh+TAA=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -12623,6 +12674,14 @@
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "=3.1.0"
+      }
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
       }
     },
     "for-in": {
@@ -15433,6 +15492,16 @@
       "integrity": "sha512-B69mWcqCmT3jNYmSxRxxOXWfzu3Go8NQXPfl2o0qPd1EEFhwW0dFUg9ztTu915zPQzqwIhWAlw6hmfIcCK4kkQ==",
       "dev": true
     },
+    "globalthis": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.0.tgz",
+      "integrity": "sha512-vcCAZTJ3r5Qcu5l8/2oyVdoFwxKgfYnMTR2vwWeux/NAVZK3PwcMaWkdUIn4GJbmKuRK7xcvDsLuK+CKcXyodg==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "object-keys": "^1.0.12"
+      }
+    },
     "globby": {
       "version": "6.1.0",
       "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -16802,18 +16871,18 @@
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "ipfs": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.37.0.tgz",
-      "integrity": "sha512-nZb/qMmq3G1IswN2g2DL9u/mdRMND5WvgChmcDiq4Z0zyntLTaCMgwnXDAnCwhXyMLanY8AlGh42nq+DQoc51A==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.38.1.tgz",
+      "integrity": "sha512-acxpMc+5E7SQ/V8bBeWmtIBuOlRqoa/GVRvQj3rb0ZZ5Io40fiTmKBsJU8aJCSOa5TeZcuzc+jDpvQgp7WW+CQ==",
       "requires": {
-        "@hapi/ammo": "^3.1.0",
-        "@hapi/boom": "^7.4.2",
-        "@hapi/hapi": "^18.3.1",
+        "@hapi/ammo": "^3.1.1",
+        "@hapi/boom": "^7.4.3",
+        "@hapi/hapi": "^18.3.2",
         "@hapi/joi": "^15.0.1",
         "array-shuffle": "^1.0.1",
         "async": "^2.6.1",
         "async-iterator-all": "^1.0.0",
-        "async-iterator-to-pull-stream": "^1.1.0",
+        "async-iterator-to-pull-stream": "^1.3.0",
         "async-iterator-to-stream": "^1.1.0",
         "base32.js": "~0.1.0",
         "bignumber.js": "^9.0.0",
@@ -16822,7 +16891,6 @@
         "bs58": "^4.0.1",
         "buffer-peek-stream": "^1.0.1",
         "byteman": "^1.3.5",
-        "callbackify": "^1.1.0",
         "cid-tool": "~0.3.0",
         "cids": "~0.7.1",
         "class-is": "^1.1.0",
@@ -16831,27 +16899,28 @@
         "debug": "^4.1.0",
         "dlv": "^1.1.3",
         "err-code": "^2.0.0",
+        "explain-error": "^1.0.4",
         "file-type": "^12.0.1",
         "fnv1a": "^1.0.1",
         "fsm-event": "^2.1.0",
         "get-folder-size": "^2.0.0",
         "glob": "^7.1.3",
-        "hapi-pino": "^6.0.0",
+        "hapi-pino": "^6.1.0",
         "hashlru": "^2.3.0",
         "human-to-milliseconds": "^2.0.0",
         "interface-datastore": "~0.6.0",
         "ipfs-bitswap": "~0.25.1",
         "ipfs-block": "~0.8.1",
         "ipfs-block-service": "~0.15.2",
-        "ipfs-http-client": "^33.1.0",
+        "ipfs-http-client": "^37.0.1",
         "ipfs-http-response": "~0.3.1",
-        "ipfs-mfs": "~0.12.0",
-        "ipfs-multipart": "~0.1.1",
+        "ipfs-mfs": "^0.12.2",
+        "ipfs-multipart": "^0.2.0",
         "ipfs-repo": "~0.26.6",
         "ipfs-unixfs": "~0.1.16",
         "ipfs-unixfs-exporter": "~0.37.7",
         "ipfs-unixfs-importer": "~0.39.11",
-        "ipfs-utils": "~0.0.4",
+        "ipfs-utils": "^0.3.0",
         "ipld": "~0.24.1",
         "ipld-bitcoin": "~0.3.0",
         "ipld-dag-cbor": "~0.15.0",
@@ -16866,30 +16935,34 @@
         "is-pull-stream": "~0.0.0",
         "is-stream": "^2.0.0",
         "iso-url": "~0.4.6",
-        "just-flatten-it": "^2.1.0",
+        "it-pipe": "^1.0.1",
+        "it-to-stream": "^0.1.1",
         "just-safe-set": "^2.1.0",
         "kind-of": "^6.0.2",
-        "libp2p": "~0.25.4",
+        "libp2p": "~0.26.1",
         "libp2p-bootstrap": "~0.9.3",
         "libp2p-crypto": "~0.16.0",
         "libp2p-delegated-content-routing": "^0.2.4",
         "libp2p-delegated-peer-routing": "^0.2.4",
+        "libp2p-floodsub": "^0.18.0",
+        "libp2p-gossipsub": "~0.0.5",
         "libp2p-kad-dht": "~0.15.3",
         "libp2p-keychain": "~0.4.2",
         "libp2p-mdns": "~0.12.0",
         "libp2p-record": "~0.6.3",
         "libp2p-secio": "~0.11.0",
-        "libp2p-tcp": "~0.13.0",
+        "libp2p-tcp": "~0.13.1",
         "libp2p-webrtc-star": "~0.16.0",
         "libp2p-websocket-star-multi": "~0.4.3",
-        "libp2p-websockets": "~0.12.2",
+        "libp2p-websockets": "~0.12.3",
         "lodash": "^4.17.15",
-        "mafmt": "^6.0.2",
+        "mafmt": "^6.0.10",
         "merge-options": "^1.0.1",
         "mime-types": "^2.1.21",
         "mkdirp": "~0.5.1",
+        "mortice": "^2.0.0",
         "multiaddr": "^6.1.0",
-        "multiaddr-to-uri": "^4.0.1",
+        "multiaddr-to-uri": "^5.0.0",
         "multibase": "~0.6.0",
         "multicodec": "~0.5.5",
         "multihashes": "~0.4.14",
@@ -16901,6 +16974,7 @@
         "progress": "^2.0.1",
         "prom-client": "^11.5.3",
         "prometheus-gc-stats": "~0.6.0",
+        "promise-nodeify": "^3.0.1",
         "promisify-es6": "^1.0.3",
         "protons": "^1.0.1",
         "pull-abortable": "^4.1.1",
@@ -16911,7 +16985,7 @@
         "pull-ndjson": "~0.1.1",
         "pull-pushable": "^2.2.0",
         "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.13",
+        "pull-stream": "^3.6.14",
         "pull-stream-to-async-iterator": "^1.0.2",
         "pull-stream-to-stream": "^1.3.4",
         "pull-traverse": "^1.0.3",
@@ -16919,16 +16993,62 @@
         "receptacle": "^1.3.2",
         "semver": "^6.3.0",
         "stream-to-pull-stream": "^1.7.3",
-        "superstruct": "~0.6.0",
+        "superstruct": "~0.6.2",
         "tar-stream": "^2.0.0",
         "temp": "~0.9.0",
         "update-notifier": "^3.0.1",
         "uri-to-multiaddr": "^3.0.1",
         "varint": "^5.0.0",
-        "yargs": "^13.3.0",
+        "yargs": "^14.0.0",
         "yargs-promise": "^1.1.0"
       },
       "dependencies": {
+        "@hapi/ammo": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.1.tgz",
+          "integrity": "sha512-NYFK27VSPGyQ/KmOQedpQH4PSjE7awLntepX68vrYtRvuJO21W1kX0bK2p3C+6ltUwtCQSvmNT8a4uMVAysC6Q==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        },
+        "@hapi/boom": {
+          "version": "7.4.11",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+          "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        },
+        "@hapi/hapi": {
+          "version": "18.4.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.0.tgz",
+          "integrity": "sha512-uk9zqknRLcNVQKgrPURm85DqkdroWP8eDRekh/IPoKvC4VjdZSn6EH2eUriOwyud/CldeBS3HDIJ/PtRj3VxDQ==",
+          "requires": {
+            "@hapi/accept": "3.x.x",
+            "@hapi/ammo": "3.x.x",
+            "@hapi/boom": "7.x.x",
+            "@hapi/bounce": "1.x.x",
+            "@hapi/call": "5.x.x",
+            "@hapi/catbox": "10.x.x",
+            "@hapi/catbox-memory": "4.x.x",
+            "@hapi/heavy": "6.x.x",
+            "@hapi/hoek": "8.x.x",
+            "@hapi/joi": "15.x.x",
+            "@hapi/mimos": "4.x.x",
+            "@hapi/podium": "3.x.x",
+            "@hapi/shot": "4.x.x",
+            "@hapi/somever": "2.x.x",
+            "@hapi/statehood": "6.x.x",
+            "@hapi/subtext": "6.x.x",
+            "@hapi/teamwork": "3.x.x",
+            "@hapi/topo": "3.x.x"
+          }
+        },
+        "@hapi/hoek": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
+          "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+        },
         "@sindresorhus/is": {
           "version": "0.14.0",
           "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -16976,24 +17096,12 @@
             "term-size": "^1.2.0",
             "type-fest": "^0.3.0",
             "widest-line": "^2.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
           }
         },
         "buffer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
-          "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -17032,6 +17140,16 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         },
         "ci-info": {
           "version": "2.0.0",
@@ -17090,6 +17208,21 @@
           "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
           "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
         },
+        "eventemitter3": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        },
+        "fast-redact": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+          "integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
+        },
+        "fast-safe-stringify": {
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+          "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+        },
         "filesize": {
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -17101,6 +17234,16 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "requires": {
             "locate-path": "^3.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "get-caller-file": {
@@ -17136,10 +17279,36 @@
             }
           }
         },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+        },
+        "hapi-pino": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-6.3.0.tgz",
+          "integrity": "sha512-r2CUXmrJ2Fcxg805RXVrtZCNpFyJ0RpLOSFXnRC6jBLV/5uGUMPk1Y/U+WVn5kHFzXbxrQ6JAgV8cfHah3qqOA==",
+          "requires": {
+            "@hapi/hoek": "^8.3.0",
+            "abstract-logging": "^1.0.0",
+            "pino": "^5.13.5",
+            "pino-pretty": "^3.2.2"
+          }
+        },
         "http-cache-semantics": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
           "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+        },
+        "ip-address": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.1.0.tgz",
+          "integrity": "sha512-u9YYtb1p2fWSbzpKmZ/b3QXWA+diRYPxc2c4y5lFB/MMk5WZ7wNZv8S3CFcIGVJ5XtlaCAl/FQy/D3eQ2XtdOA==",
+          "requires": {
+            "jsbn": "1.1.0",
+            "lodash": "^4.17.15",
+            "sprintf-js": "1.1.2"
+          }
         },
         "ipfs-http-response": {
           "version": "0.3.1",
@@ -17167,9 +17336,9 @@
           }
         },
         "ipfs-mfs": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.12.0.tgz",
-          "integrity": "sha512-EY+At/kw2Lsyfd/AFInmvR2O6MQvQ87RWhAnN3GXSy/tXaopaS5CqT9SSUVAx3we87/pAUbusxQ1pK7HYtrXSw==",
+          "version": "0.12.2",
+          "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.12.2.tgz",
+          "integrity": "sha512-o9vGKEdUI4HwQV67DQnC1AVSSs7i/yaIHrKPEb6Oe6vGeobLGuEGMReWjTcnMi5KAKUECFESEVtDuNJDr8BW5Q==",
           "requires": {
             "@hapi/boom": "^7.4.2",
             "@hapi/joi": "^15.1.0",
@@ -17179,13 +17348,13 @@
             "err-code": "^1.1.2",
             "hamt-sharding": "~0.0.2",
             "interface-datastore": "~0.6.0",
-            "ipfs-multipart": "~0.1.0",
+            "ipfs-multipart": "~0.2.0",
             "ipfs-unixfs": "~0.1.16",
             "ipfs-unixfs-exporter": "~0.37.6",
             "ipfs-unixfs-importer": "~0.39.9",
             "ipld-dag-pb": "~0.17.2",
             "joi-browser": "^13.4.0",
-            "mortice": "^1.2.1",
+            "mortice": "^2.0.0",
             "multicodec": "~0.5.3",
             "multihashes": "~0.4.14",
             "once": "^1.4.0",
@@ -17198,6 +17367,33 @@
               "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
               "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
             }
+          }
+        },
+        "ipfs-multipart": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ipfs-multipart/-/ipfs-multipart-0.2.0.tgz",
+          "integrity": "sha512-pDCr7xtOW7KCqgeGmejfWjm5xPH516Kx4OU/PdbtIZu68/cFPW4jftJy9idQHdf0C/NnKHnqntMY93rbc+qrQg==",
+          "requires": {
+            "@hapi/content": "^4.1.0",
+            "it-multipart": "~0.0.2"
+          }
+        },
+        "ipfs-utils": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.3.0.tgz",
+          "integrity": "sha512-5xrOYv27lA8gV13K6Zm8gIUvNtqwmHCqztxnVE4S6aTdfMNkXQJJhRvlsi7RN/auHMORPxc3qSRMukgEUO3C2Q==",
+          "requires": {
+            "buffer": "^5.2.1",
+            "err-code": "^2.0.0",
+            "fs-extra": "^8.1.0",
+            "is-buffer": "^2.0.3",
+            "is-electron": "^2.2.0",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "it-glob": "0.0.4",
+            "kind-of": "^6.0.2",
+            "pull-stream-to-async-iterator": "^1.0.2",
+            "readable-stream": "^3.4.0"
           }
         },
         "ipld-dag-pb": {
@@ -17233,6 +17429,11 @@
             }
           }
         },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        },
         "is-ci": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -17252,16 +17453,6 @@
             "multiaddr": "^6.0.4",
             "multibase": "~0.6.0",
             "multihashes": "~0.4.13"
-          },
-          "dependencies": {
-            "mafmt": {
-              "version": "6.0.8",
-              "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.8.tgz",
-              "integrity": "sha512-6oRO2fwNiqXXiby8Anq9ULLQpcrZUsfR3Bs+Yn1DWd/Zd65xGS9fobKzzSsnM9nqUdUA3IggG0b1R3WamVsatA==",
-              "requires": {
-                "multiaddr": "^6.1.0"
-              }
-            }
           }
         },
         "is-npm": {
@@ -17279,12 +17470,134 @@
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
           "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         },
+        "jsbn": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+          "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+        },
         "latest-version": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
           "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
           "requires": {
             "package-json": "^6.3.0"
+          }
+        },
+        "libp2p": {
+          "version": "0.26.2",
+          "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.26.2.tgz",
+          "integrity": "sha512-AaPSpROjrg17QBMood6tdxLj3yWH5qR/pnQ4gurz3byvYvD6Tw3yt7PQRdSyjOh6Oh+EX06yTrNCnoDTdgliKg==",
+          "requires": {
+            "async": "^2.6.2",
+            "bignumber.js": "^9.0.0",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "err-code": "^1.1.2",
+            "fsm-event": "^2.1.0",
+            "hashlru": "^2.3.0",
+            "interface-connection": "~0.3.3",
+            "latency-monitor": "~0.2.1",
+            "libp2p-crypto": "~0.16.1",
+            "libp2p-websockets": "^0.12.2",
+            "mafmt": "^6.0.7",
+            "merge-options": "^1.0.1",
+            "moving-average": "^1.0.0",
+            "multiaddr": "^6.1.0",
+            "multistream-select": "~0.14.6",
+            "once": "^1.4.0",
+            "peer-book": "^0.9.1",
+            "peer-id": "^0.12.2",
+            "peer-info": "~0.15.1",
+            "promisify-es6": "^1.0.3",
+            "protons": "^1.0.1",
+            "pull-cat": "^1.1.11",
+            "pull-defer": "~0.2.3",
+            "pull-handshake": "^1.1.4",
+            "pull-reader": "^1.3.1",
+            "pull-stream": "^3.6.9",
+            "retimer": "^2.0.0",
+            "superstruct": "^0.6.0",
+            "xsalsa20": "^1.0.2"
+          },
+          "dependencies": {
+            "err-code": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+              "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+            }
+          }
+        },
+        "libp2p-floodsub": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.18.0.tgz",
+          "integrity": "sha512-4OihLP5A4LsxNPlfb0mq6vkjAaNu4YxuyYeoj2nNgrRSzr4H8Dz0YtA+DzEDXIgP2RBANSzS+KG9oDeUXDHa/Q==",
+          "requires": {
+            "async": "^2.6.2",
+            "bs58": "^4.0.1",
+            "debug": "^4.1.1",
+            "length-prefixed-stream": "^2.0.0",
+            "libp2p-crypto": "~0.16.1",
+            "libp2p-pubsub": "~0.2.0",
+            "protons": "^1.0.1",
+            "pull-length-prefixed": "^1.3.2",
+            "pull-pushable": "^2.2.0",
+            "pull-stream": "^3.6.9"
+          }
+        },
+        "libp2p-pubsub": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.2.1.tgz",
+          "integrity": "sha512-6LFl7b/39LLWKK9v/Oz9F7+c0WX8t2W2Qf2nwyMMCtJDGxC3csvXdhWwUDzBwXx704BJhVgpsVVJ4fXQn5gahg==",
+          "requires": {
+            "async": "^2.6.2",
+            "bs58": "^4.0.1",
+            "debug": "^4.1.1",
+            "err-code": "^1.1.2",
+            "length-prefixed-stream": "^2.0.0",
+            "libp2p-crypto": "~0.16.1",
+            "protons": "^1.0.1",
+            "pull-length-prefixed": "^1.3.1",
+            "pull-pushable": "^2.2.0",
+            "pull-stream": "^3.6.9",
+            "sinon": "^7.3.2",
+            "time-cache": "~0.3.0"
+          },
+          "dependencies": {
+            "err-code": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+              "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+            }
+          }
+        },
+        "libp2p-tcp": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.13.2.tgz",
+          "integrity": "sha512-TvHLCn25m+UIH+hXTuy8xJDU/Kxj8EEEgWzhWUImsrb/YsYFywjbuv8YCAYtTUMIzyT2DnTtM+xzPxccg/sytw==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "interface-connection": "~0.3.3",
+            "ip-address": "^6.1.0",
+            "lodash.includes": "^4.3.0",
+            "lodash.isfunction": "^3.0.9",
+            "mafmt": "^6.0.7",
+            "multiaddr": "^6.1.0",
+            "once": "^1.4.0",
+            "stream-to-pull-stream": "^1.7.3"
+          }
+        },
+        "libp2p-websockets": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.4.tgz",
+          "integrity": "sha512-wXrdFgBibvuD+b+s1KIvhlbzh/qCXSDBmzkoKUugftxV6tC5AhotbHW1JlcI726+U+z4k8ha3nEZd9PY64NLqQ==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "interface-connection": "~0.3.3",
+            "mafmt": "^6.0.7",
+            "multiaddr-to-uri": "^5.0.0",
+            "pull-ws": "github:hugomrdias/pull-ws#fix/bundle-size"
           }
         },
         "locate-path": {
@@ -17301,15 +17614,35 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
+        "mafmt": {
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
+          "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
+          "requires": {
+            "multiaddr": "^6.1.0"
+          }
+        },
+        "mortice": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mortice/-/mortice-2.0.0.tgz",
+          "integrity": "sha512-rXcjRgv2MRhpwGHErxKcDcp5IoA9CPvPFLXmmseQYIuQ2fSVu8tsMKi/eYUXzp/HH1s6y3IID/GwRqlSglDdRA==",
+          "requires": {
+            "globalthis": "^1.0.0",
+            "observable-webworkers": "^1.0.0",
+            "p-queue": "^6.0.0",
+            "promise-timeout": "^1.3.0",
+            "shortid": "^2.2.8"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
+          "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
           "requires": {
             "bs58": "^4.0.1",
             "class-is": "^1.1.0",
@@ -17317,6 +17650,14 @@
             "ip": "^1.1.5",
             "is-ip": "^2.0.0",
             "varint": "^5.0.0"
+          }
+        },
+        "multiaddr-to-uri": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.0.0.tgz",
+          "integrity": "sha512-aVc52fdGXso3DwvVKUTjMddhLyuFBXcpGSbsIju0lKiYKFBUEREXSLpcqTOZlO8w1G1TivVmDe4CBUKQ/xMm5A==",
+          "requires": {
+            "multiaddr": "^6.1.0"
           }
         },
         "multicodec": {
@@ -17345,9 +17686,9 @@
           "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "normalize-url": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
-          "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ=="
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
         },
         "p-cancelable": {
           "version": "1.1.0",
@@ -17368,6 +17709,23 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "requires": {
             "p-limit": "^2.0.0"
+          }
+        },
+        "p-queue": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.2.0.tgz",
+          "integrity": "sha512-B2LXNONcyn/G6uz2UBFsGjmSa0e/br3jznlzhEyCXg56c7VhEpiT2pZxGOfv32Q3FSyugAdys9KGpsv3kV+Sbg==",
+          "requires": {
+            "eventemitter3": "^4.0.0",
+            "p-timeout": "^3.1.0"
+          }
+        },
+        "p-timeout": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+          "requires": {
+            "p-finally": "^1.0.0"
           }
         },
         "p-try": {
@@ -17397,6 +17755,35 @@
             "unique-by": "^1.0.0"
           }
         },
+        "pino": {
+          "version": "5.13.5",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-5.13.5.tgz",
+          "integrity": "sha512-NSArDZnjIXgzTLsYA5EhYwLiMe2OmGJ73760Wt5Vj44kUcuPJk4ub29BKtWXGAMwVmW1cQ7Q8jQaLjY/5Gxqcw==",
+          "requires": {
+            "fast-redact": "^2.0.0",
+            "fast-safe-stringify": "^2.0.7",
+            "flatstr": "^1.0.9",
+            "pino-std-serializers": "^2.3.0",
+            "quick-format-unescaped": "^3.0.3",
+            "sonic-boom": "^0.7.5"
+          }
+        },
+        "pino-pretty": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-3.2.2.tgz",
+          "integrity": "sha512-2SP++Wbo4EsH5RpLhcsYHOR/8CMTIJWZpU0aPiVK0Wq8SrRMQ9oHQNffVK5ZyDFZMtSuTdFCVfLVNFmtFMDEeA==",
+          "requires": {
+            "@hapi/bourne": "^1.3.2",
+            "args": "^5.0.1",
+            "chalk": "^2.4.2",
+            "dateformat": "^3.0.3",
+            "fast-safe-stringify": "^2.0.7",
+            "jmespath": "^0.15.0",
+            "pump": "^3.0.0",
+            "readable-stream": "^3.4.0",
+            "split2": "^3.1.1"
+          }
+        },
         "prepend-http": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -17406,6 +17793,11 @@
           "version": "3.6.14",
           "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
           "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
+        },
+        "quick-format-unescaped": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+          "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
         },
         "readable-stream": {
           "version": "3.4.0",
@@ -17444,6 +17836,19 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
+        "split2": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+          "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+          "requires": {
+            "readable-stream": "^3.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        },
         "stream-to-pull-stream": {
           "version": "1.7.3",
           "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
@@ -17469,6 +17874,15 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
+          }
+        },
+        "superstruct": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.6.2.tgz",
+          "integrity": "sha512-lvA97MFAJng3rfjcafT/zGTSWm6Tbpk++DP6It4Qg7oNaeM+2tdJMuVgGje21/bIpBEs6iQql1PJH6dKTjl4Ig==",
+          "requires": {
+            "clone-deep": "^2.0.1",
+            "kind-of": "^6.0.1"
           }
         },
         "tar-stream": {
@@ -17526,11 +17940,12 @@
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
         },
         "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
+          "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
           "requires": {
             "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
             "find-up": "^3.0.0",
             "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
@@ -17539,13 +17954,13 @@
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
+            "yargs-parser": "^15.0.0"
           }
         },
         "yargs-parser": {
-          "version": "13.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -17664,25 +18079,32 @@
       }
     },
     "ipfs-http-client": {
-      "version": "33.1.1",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-33.1.1.tgz",
-      "integrity": "sha512-iwtLL3lOIzxXJFwLnOEtFUv1cYTuWJ0NauD7rpMEd/y4C7z6fuN6TSF4h547lxMh7sJWv+6Z0PmOA5N8FzUHJw==",
+      "version": "37.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-37.0.3.tgz",
+      "integrity": "sha512-yv8lVWGUWcAX5K1K5gj0uWjIBmvbS0hIhnStC4Da+RTJL09jFj9LsBYySst8F3pmU6XfqOurwihlFmK79ZChyg==",
       "requires": {
+        "abort-controller": "^3.0.0",
         "async": "^2.6.1",
+        "async-iterator-all": "^1.0.0",
+        "async-iterator-to-pull-stream": "^1.3.0",
         "bignumber.js": "^9.0.0",
         "bl": "^3.0.0",
         "bs58": "^4.0.1",
-        "buffer": "^5.2.1",
+        "buffer": "^5.4.2",
         "cids": "~0.7.1",
         "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
         "debug": "^4.1.0",
+        "delay": "^4.3.0",
         "detect-node": "^2.0.4",
         "end-of-stream": "^1.4.1",
-        "err-code": "^1.1.2",
+        "err-code": "^2.0.0",
+        "explain-error": "^1.0.4",
         "flatmap": "0.0.3",
+        "form-data": "^2.5.1",
+        "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
         "ipfs-block": "~0.8.1",
-        "ipfs-utils": "~0.0.3",
+        "ipfs-utils": "^0.4.0",
         "ipld-dag-cbor": "~0.15.0",
         "ipld-dag-pb": "~0.17.3",
         "ipld-raw": "^4.0.0",
@@ -17691,21 +18113,29 @@
         "is-stream": "^2.0.0",
         "iso-stream-http": "~0.1.2",
         "iso-url": "~0.4.6",
+        "it-glob": "0.0.4",
+        "it-to-stream": "^0.1.1",
+        "iterable-ndjson": "^1.1.0",
         "just-kebab-case": "^1.1.0",
         "just-map-keys": "^1.1.0",
         "kind-of": "^6.0.2",
+        "ky": "^0.14.0",
+        "ky-universal": "^0.3.0",
         "lru-cache": "^5.1.1",
+        "merge-options": "^1.0.1",
         "multiaddr": "^6.0.6",
         "multibase": "~0.6.0",
         "multicodec": "~0.5.1",
         "multihashes": "~0.4.14",
         "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
         "once": "^1.4.0",
-        "peer-id": "~0.12.2",
+        "peer-id": "~0.12.3",
         "peer-info": "~0.15.1",
+        "promise-nodeify": "^3.0.1",
         "promisify-es6": "^1.0.3",
         "pull-defer": "~0.2.3",
         "pull-stream": "^3.6.9",
+        "pull-stream-to-async-iterator": "^1.0.2",
         "pull-to-stream": "~0.1.1",
         "pump": "^3.0.0",
         "qs": "^6.5.2",
@@ -17732,9 +18162,9 @@
           }
         },
         "buffer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
-          "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -17767,6 +18197,54 @@
             "ms": "^2.1.1"
           }
         },
+        "err-code": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
+          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+        },
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+        },
+        "ipfs-utils": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.4.0.tgz",
+          "integrity": "sha512-JLFmCcA058knmYiSB+WBw6nxcDHFS6p05weQOTFR/edufYot0UpgsJTcoMd1fHMq81n0nciJ3QQBqLcJxqGqhA==",
+          "requires": {
+            "buffer": "^5.2.1",
+            "err-code": "^2.0.0",
+            "fs-extra": "^8.1.0",
+            "is-buffer": "^2.0.3",
+            "is-electron": "^2.2.0",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "it-glob": "0.0.4",
+            "kind-of": "^6.0.2",
+            "pull-stream-to-async-iterator": "^1.0.2",
+            "readable-stream": "^3.4.0"
+          }
+        },
         "ipld-dag-pb": {
           "version": "0.17.4",
           "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.17.4.tgz",
@@ -17779,6 +18257,11 @@
             "protons": "^1.0.1",
             "stable": "~0.1.8"
           }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         },
         "is-ipfs": {
           "version": "0.6.1",
@@ -17817,9 +18300,9 @@
           }
         },
         "mafmt": {
-          "version": "6.0.8",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.8.tgz",
-          "integrity": "sha512-6oRO2fwNiqXXiby8Anq9ULLQpcrZUsfR3Bs+Yn1DWd/Zd65xGS9fobKzzSsnM9nqUdUA3IggG0b1R3WamVsatA==",
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
+          "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
           "requires": {
             "multiaddr": "^6.1.0"
           }
@@ -17830,9 +18313,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
+          "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
           "requires": {
             "bs58": "^4.0.1",
             "class-is": "^1.1.0",
@@ -17853,6 +18336,13 @@
             "js-sha3": "~0.8.0",
             "multihashes": "~0.4.13",
             "murmurhash3js-revisited": "^3.0.0"
+          },
+          "dependencies": {
+            "err-code": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+              "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+            }
           }
         },
         "peer-info": {
@@ -17897,9 +18387,9 @@
           }
         },
         "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -19592,6 +20082,108 @@
         "is-object": "^1.0.1"
       }
     },
+    "it-glob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.4.tgz",
+      "integrity": "sha512-sTMM62VQWRqlMpgbd+x1uTviQY7a8vMLXYmw+KPiV9vmAYuyIr9Sp1QRQ5B/faybf4O9RzMGyQb7eFpqLwsBhQ==",
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+        }
+      }
+    },
+    "it-multipart": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/it-multipart/-/it-multipart-0.0.2.tgz",
+      "integrity": "sha512-Mlvf1Tt+gLyk5EkE9njjfDCuvf5+3rx1vDt271MT7Ye08/3yJL/h+M/EWhPBPLebmNrkfXUQOGl8ud4T9PzuWA==",
+      "requires": {
+        "buffer-indexof": "^1.1.1",
+        "parse-headers": "^2.0.2"
+      }
+    },
+    "it-pipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.0.1.tgz",
+      "integrity": "sha512-clx7NMIf4eXe3rp4dKLmT5vMYv/hvZv4lNi1/xx4ZJ8CFmpGod9rTKisyBNBTurbCEa3a7503COankdBj/uUCA=="
+    },
+    "it-to-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.1.tgz",
+      "integrity": "sha512-QQx/58JBvT189imr6fD234F8aVf8EdyQHJR0MxXAOShEWK1NWyahPYIQt/tQG7PId0ZG/6/3tUiVCfw2cq+e1w==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "p-defer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "iterable-ndjson": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
+      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+      "requires": {
+        "string_decoder": "^1.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "iterall": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
@@ -19844,6 +20436,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-1.1.0.tgz",
       "integrity": "sha512-87Nnc0qZKgBZuhFZjYVjSraic0x7zwjhaTMrCKlj0QYKH6lh0KbFzVnfu6LHan03NO7J8ygjeBeD0epejn5Zcg=="
+    },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
     },
     "just-flatten-it": {
       "version": "2.1.0",
@@ -20207,6 +20804,27 @@
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.10.0.tgz",
       "integrity": "sha512-OMPb86bpVbnKN/2VJw1Ggs1Hw/FNGwEL1QYiNIEHaB5FSLybJ4QD7My5Hm9yDhgpRrRnnOgu0oKeuuABzASeBw==",
       "dev": true
+    },
+    "ky": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.14.0.tgz",
+      "integrity": "sha512-NSjg+WCElQPdlF3BFZnjh8s5QlMIP+vIGoyukrRU+n+23VBUX87bQYOoG5h3HX5tO7kKQYXvg+QZVt8n0uWmhg=="
+    },
+    "ky-universal": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.3.0.tgz",
+      "integrity": "sha512-CM4Bgb2zZZpsprcjI6DNYTaH3oGHXL2u7BU4DK+lfCuC4snkt9/WRpMYeKbBbXscvKkeqBwzzjFX2WwmKY5K/A==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
+      }
     },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
@@ -20932,20 +21550,173 @@
             "lodash": "^4.17.14"
           }
         },
+        "bl": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+          "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+          "requires": {
+            "readable-stream": "^3.0.1"
+          }
+        },
+        "buffer": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "cids": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.1.tgz",
+          "integrity": "sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.5.1",
+            "multihashes": "~0.4.14"
+          }
+        },
+        "concat-stream": {
+          "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+          "from": "github:hugomrdias/concat-stream#feat/smaller",
+          "requires": {
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "eventemitter3": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
           "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        },
+        "ipfs-http-client": {
+          "version": "33.1.1",
+          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-33.1.1.tgz",
+          "integrity": "sha512-iwtLL3lOIzxXJFwLnOEtFUv1cYTuWJ0NauD7rpMEd/y4C7z6fuN6TSF4h547lxMh7sJWv+6Z0PmOA5N8FzUHJw==",
+          "requires": {
+            "async": "^2.6.1",
+            "bignumber.js": "^9.0.0",
+            "bl": "^3.0.0",
+            "bs58": "^4.0.1",
+            "buffer": "^5.2.1",
+            "cids": "~0.7.1",
+            "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+            "debug": "^4.1.0",
+            "detect-node": "^2.0.4",
+            "end-of-stream": "^1.4.1",
+            "err-code": "^1.1.2",
+            "flatmap": "0.0.3",
+            "glob": "^7.1.3",
+            "ipfs-block": "~0.8.1",
+            "ipfs-utils": "~0.0.3",
+            "ipld-dag-cbor": "~0.15.0",
+            "ipld-dag-pb": "~0.17.3",
+            "ipld-raw": "^4.0.0",
+            "is-ipfs": "~0.6.1",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "iso-stream-http": "~0.1.2",
+            "iso-url": "~0.4.6",
+            "just-kebab-case": "^1.1.0",
+            "just-map-keys": "^1.1.0",
+            "kind-of": "^6.0.2",
+            "lru-cache": "^5.1.1",
+            "multiaddr": "^6.0.6",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.5.1",
+            "multihashes": "~0.4.14",
+            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+            "once": "^1.4.0",
+            "peer-id": "~0.12.2",
+            "peer-info": "~0.15.1",
+            "promisify-es6": "^1.0.3",
+            "pull-defer": "~0.2.3",
+            "pull-stream": "^3.6.9",
+            "pull-to-stream": "~0.1.1",
+            "pump": "^3.0.0",
+            "qs": "^6.5.2",
+            "readable-stream": "^3.1.1",
+            "stream-to-pull-stream": "^1.7.2",
+            "tar-stream": "^2.0.1",
+            "through2": "^3.0.1"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.17.4",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.17.4.tgz",
+          "integrity": "sha512-YwCxETEMuXVspOKOhjIOHJvKvB/OZfCDkpSFiYBQN2/JQjM9y/RFCYzIQGm0wg7dCFLrhvfjAZLTSaKs65jzWA==",
+          "requires": {
+            "cids": "~0.7.0",
+            "class-is": "^1.1.0",
+            "multicodec": "~0.5.1",
+            "multihashing-async": "~0.7.0",
+            "protons": "^1.0.1",
+            "stable": "~0.1.8"
+          }
+        },
+        "is-ipfs": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.1.tgz",
+          "integrity": "sha512-WhqQylam6pODS2RyqT/u0PR5KWtBZNCgPjgargFOVQjzw/3+6d0midXenzU65klM4LH13IUiCC6ObhDUdXZ7Nw==",
+          "requires": {
+            "bs58": "^4.0.1",
+            "cids": "~0.7.0",
+            "mafmt": "^6.0.7",
+            "multiaddr": "^6.0.4",
+            "multibase": "~0.6.0",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         },
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "mafmt": {
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
+          "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
+          "requires": {
+            "multiaddr": "^6.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
+          "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
           "requires": {
             "bs58": "^4.0.1",
             "class-is": "^1.1.0",
@@ -20955,19 +21726,32 @@
             "varint": "^5.0.0"
           }
         },
+        "multihashing-async": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.7.0.tgz",
+          "integrity": "sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.2.1",
+            "err-code": "^1.1.2",
+            "js-sha3": "~0.8.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
         "p-queue": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.1.1.tgz",
-          "integrity": "sha512-R9gq36Th88xZ+rWAptN5IXLwqkwA1gagCQhT6ZXQ6RxEfmjb9ZW+UBzRVqv9sm5TQmbbI/TsKgGLbOaA61xR5w==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.2.0.tgz",
+          "integrity": "sha512-B2LXNONcyn/G6uz2UBFsGjmSa0e/br3jznlzhEyCXg56c7VhEpiT2pZxGOfv32Q3FSyugAdys9KGpsv3kV+Sbg==",
           "requires": {
             "eventemitter3": "^4.0.0",
             "p-timeout": "^3.1.0"
           }
         },
         "p-timeout": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.1.0.tgz",
-          "integrity": "sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -20982,6 +21766,41 @@
             "peer-id": "~0.12.2",
             "unique-by": "^1.0.0"
           }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "tar-stream": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+          "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+          "requires": {
+            "bl": "^3.0.0",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -20996,15 +21815,181 @@
         "peer-info": "^0.15.1"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "bl": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+          "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+          "requires": {
+            "readable-stream": "^3.0.1"
+          }
+        },
+        "buffer": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "cids": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.1.tgz",
+          "integrity": "sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.5.1",
+            "multihashes": "~0.4.14"
+          }
+        },
+        "concat-stream": {
+          "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+          "from": "github:hugomrdias/concat-stream#feat/smaller",
+          "requires": {
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "eventemitter3": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
           "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
         },
+        "ipfs-http-client": {
+          "version": "33.1.1",
+          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-33.1.1.tgz",
+          "integrity": "sha512-iwtLL3lOIzxXJFwLnOEtFUv1cYTuWJ0NauD7rpMEd/y4C7z6fuN6TSF4h547lxMh7sJWv+6Z0PmOA5N8FzUHJw==",
+          "requires": {
+            "async": "^2.6.1",
+            "bignumber.js": "^9.0.0",
+            "bl": "^3.0.0",
+            "bs58": "^4.0.1",
+            "buffer": "^5.2.1",
+            "cids": "~0.7.1",
+            "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+            "debug": "^4.1.0",
+            "detect-node": "^2.0.4",
+            "end-of-stream": "^1.4.1",
+            "err-code": "^1.1.2",
+            "flatmap": "0.0.3",
+            "glob": "^7.1.3",
+            "ipfs-block": "~0.8.1",
+            "ipfs-utils": "~0.0.3",
+            "ipld-dag-cbor": "~0.15.0",
+            "ipld-dag-pb": "~0.17.3",
+            "ipld-raw": "^4.0.0",
+            "is-ipfs": "~0.6.1",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "iso-stream-http": "~0.1.2",
+            "iso-url": "~0.4.6",
+            "just-kebab-case": "^1.1.0",
+            "just-map-keys": "^1.1.0",
+            "kind-of": "^6.0.2",
+            "lru-cache": "^5.1.1",
+            "multiaddr": "^6.0.6",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.5.1",
+            "multihashes": "~0.4.14",
+            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+            "once": "^1.4.0",
+            "peer-id": "~0.12.2",
+            "peer-info": "~0.15.1",
+            "promisify-es6": "^1.0.3",
+            "pull-defer": "~0.2.3",
+            "pull-stream": "^3.6.9",
+            "pull-to-stream": "~0.1.1",
+            "pump": "^3.0.0",
+            "qs": "^6.5.2",
+            "readable-stream": "^3.1.1",
+            "stream-to-pull-stream": "^1.7.2",
+            "tar-stream": "^2.0.1",
+            "through2": "^3.0.1"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.17.4",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.17.4.tgz",
+          "integrity": "sha512-YwCxETEMuXVspOKOhjIOHJvKvB/OZfCDkpSFiYBQN2/JQjM9y/RFCYzIQGm0wg7dCFLrhvfjAZLTSaKs65jzWA==",
+          "requires": {
+            "cids": "~0.7.0",
+            "class-is": "^1.1.0",
+            "multicodec": "~0.5.1",
+            "multihashing-async": "~0.7.0",
+            "protons": "^1.0.1",
+            "stable": "~0.1.8"
+          }
+        },
+        "is-ipfs": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.1.tgz",
+          "integrity": "sha512-WhqQylam6pODS2RyqT/u0PR5KWtBZNCgPjgargFOVQjzw/3+6d0midXenzU65klM4LH13IUiCC6ObhDUdXZ7Nw==",
+          "requires": {
+            "bs58": "^4.0.1",
+            "cids": "~0.7.0",
+            "mafmt": "^6.0.7",
+            "multiaddr": "^6.0.4",
+            "multibase": "~0.6.0",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "mafmt": {
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
+          "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
+          "requires": {
+            "multiaddr": "^6.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
+          "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
           "requires": {
             "bs58": "^4.0.1",
             "class-is": "^1.1.0",
@@ -21014,19 +21999,32 @@
             "varint": "^5.0.0"
           }
         },
+        "multihashing-async": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.7.0.tgz",
+          "integrity": "sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.2.1",
+            "err-code": "^1.1.2",
+            "js-sha3": "~0.8.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
         "p-queue": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.1.1.tgz",
-          "integrity": "sha512-R9gq36Th88xZ+rWAptN5IXLwqkwA1gagCQhT6ZXQ6RxEfmjb9ZW+UBzRVqv9sm5TQmbbI/TsKgGLbOaA61xR5w==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.2.0.tgz",
+          "integrity": "sha512-B2LXNONcyn/G6uz2UBFsGjmSa0e/br3jznlzhEyCXg56c7VhEpiT2pZxGOfv32Q3FSyugAdys9KGpsv3kV+Sbg==",
           "requires": {
             "eventemitter3": "^4.0.0",
             "p-timeout": "^3.1.0"
           }
         },
         "p-timeout": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.1.0.tgz",
-          "integrity": "sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -21041,6 +22039,41 @@
             "peer-id": "~0.12.2",
             "unique-by": "^1.0.0"
           }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "tar-stream": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+          "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+          "requires": {
+            "bl": "^3.0.0",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -21086,6 +22119,116 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "libp2p-gossipsub": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.0.5.tgz",
+      "integrity": "sha512-7IM9hcSkc7pBWEju/a5ZGcUrEHclgVoUU7XPrMsMB7s5QNXziSbLjJvIBlgU7WOxoTmgmZldEtHPkrsPEb1C9A==",
+      "requires": {
+        "async": "^2.6.2",
+        "err-code": "^1.1.2",
+        "libp2p-floodsub": "~0.17.1",
+        "libp2p-pubsub": "~0.2.0",
+        "multistream-select": "~0.14.6",
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1",
+        "protons": "^1.0.1",
+        "pull-length-prefixed": "^1.3.3",
+        "pull-stream": "^3.6.13"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "libp2p-floodsub": {
+          "version": "0.17.2",
+          "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.17.2.tgz",
+          "integrity": "sha512-xOljtBcNTerBwRYFnXlJVmTwdYla9YTvBux6HaBE0GvVjPHqOI7gO5WJQ1Nul/7h5qLX5tJqZ4OY5CVn+mcuUQ==",
+          "requires": {
+            "async": "^2.6.2",
+            "bs58": "^4.0.1",
+            "debug": "^4.1.1",
+            "length-prefixed-stream": "^2.0.0",
+            "libp2p-crypto": "~0.16.1",
+            "libp2p-pubsub": "~0.2.0",
+            "protons": "^1.0.1",
+            "pull-length-prefixed": "^1.3.2",
+            "pull-pushable": "^2.2.0",
+            "pull-stream": "^3.6.9"
+          }
+        },
+        "libp2p-pubsub": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.2.1.tgz",
+          "integrity": "sha512-6LFl7b/39LLWKK9v/Oz9F7+c0WX8t2W2Qf2nwyMMCtJDGxC3csvXdhWwUDzBwXx704BJhVgpsVVJ4fXQn5gahg==",
+          "requires": {
+            "async": "^2.6.2",
+            "bs58": "^4.0.1",
+            "debug": "^4.1.1",
+            "err-code": "^1.1.2",
+            "length-prefixed-stream": "^2.0.0",
+            "libp2p-crypto": "~0.16.1",
+            "protons": "^1.0.1",
+            "pull-length-prefixed": "^1.3.1",
+            "pull-pushable": "^2.2.0",
+            "pull-stream": "^3.6.9",
+            "sinon": "^7.3.2",
+            "time-cache": "~0.3.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "multiaddr": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
+          "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
+          "requires": {
+            "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
+            "hi-base32": "~0.5.0",
+            "ip": "^1.1.5",
+            "is-ip": "^2.0.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "peer-info": {
+          "version": "0.15.1",
+          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
+          "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
+          "requires": {
+            "mafmt": "^6.0.2",
+            "multiaddr": "^6.0.3",
+            "peer-id": "~0.12.2",
+            "unique-by": "^1.0.0"
+          }
+        },
+        "pull-stream": {
+          "version": "3.6.14",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
+          "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
         }
       }
     },
@@ -22625,6 +23768,11 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
     },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg=="
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -23798,6 +24946,33 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-abi": {
       "version": "2.5.0",
@@ -25284,6 +26459,11 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
       "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
     },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+    },
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -25612,6 +26792,22 @@
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
+    "p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "requires": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+        }
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -25852,6 +27048,15 @@
             "is-extglob": "^1.0.0"
           }
         }
+      }
+    },
+    "parse-headers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
+      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
+      "requires": {
+        "for-each": "^0.3.3",
+        "string.prototype.trim": "^1.1.2"
       }
     },
     "parse-json": {
@@ -29397,6 +30602,11 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
+    "promise-nodeify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/promise-nodeify/-/promise-nodeify-3.0.1.tgz",
+      "integrity": "sha512-ghsSuzZXJX8iO7WVec2z7GI+Xk/EyiD+JZK7AZKhUqYfpLa/Zs4ylUD+CwwnKlG6G3HnkUPMAi6PO7zeqGKssg=="
+    },
     "promise-timeout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
@@ -32669,6 +33879,27 @@
         }
       }
     },
+    "sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        }
+      }
+    },
     "sister": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.1.tgz",
@@ -33484,6 +34715,58 @@
             "ansi-regex": "^3.0.0"
           }
         }
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
+      "integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0",
+        "function-bind": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+          "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -34898,8 +36181,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.3.1",
@@ -36891,6 +38173,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
       "integrity": "sha512-AsAqZfPAuWx7qB/0kyRDUEvoU3QKsHWzHU9smFlkaiprEpGfJ/NBbLze2Uq0rdkxCxkNM9uOLvz/KoNBCbZiLQ=="
+    },
+    "xsalsa20": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.0.2.tgz",
+      "integrity": "sha512-g1DFmZ5JJ9Qzvt4dMw6m9IydqoCSP381ucU5zm46Owbk3bwmqAr8eEJirOPc7PrXRn45drzOpAyDp8jsnoyXyw=="
     },
     "xstate": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gatsby-plugin-postcss": "^2.0.0",
     "gatsby-plugin-react-helmet": "^3.0.1",
     "intersection-observer": "~0.5.0",
-    "ipfs": "^0.38.0",
+    "ipfs": "~0.38.0",
     "normalize.css": "^8.0.0",
     "postcss-import": "^12.0.0",
     "postcss-preset-moxy": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gatsby-plugin-postcss": "^2.0.0",
     "gatsby-plugin-react-helmet": "^3.0.1",
     "intersection-observer": "~0.5.0",
-    "ipfs": "~0.37.0",
+    "ipfs": "^0.38.0",
     "normalize.css": "^8.0.0",
     "postcss-import": "^12.0.0",
     "postcss-preset-moxy": "^2.3.1",

--- a/src/shared/utils/react-live.js
+++ b/src/shared/utils/react-live.js
@@ -2,8 +2,9 @@ const codeAdd = `const node = await IPFS.create()
 
 const data = 'Hello, <YOUR NAME HERE>'
 
-// convert your data to a Buffer and add it to IPFS
-const files = await node.add(IPFS.Buffer.from(data))
+// add your data to to IPFS - this can be a string, a Buffer,
+// a stream of Buffers, etc
+const files = await node.add(data)
 
 // 'hash', known as CID, is a string uniquely addressing the data
 // and can be used to get it again. 'files' is an array because
@@ -14,7 +15,7 @@ const codeGet = (cid) => `const node = await IPFS.create()
 
 const data = await node.cat('${cid}')
 
-// convert Buffer back to string
+// data is returned as a Buffer, conver it back to a string
 console.log(data.toString())`
 
 function transformCode (code) {


### PR DESCRIPTION
Updates `ipfs` dep to `^0.38.0` which can take strings as input to `ipfs.add` - no need to convert to a `Buffer` first.