### PR TITLE
fix: broken tutorial links

### DIFF
--- a/src/shared/components/getting-started-section/index.js
+++ b/src/shared/components/getting-started-section/index.js
@@ -102,7 +102,7 @@ jsipfs cat ${cid}` } language='bash' />
             <p className={ styles.liveSnippetSubtitle }>{ messages.gettingStarted.usingGateway }</p>
             <Link className={ styles.liveSnippetLink } href={ `https://ipfs.io/ipfs/${cid}` }>{ `https://ipfs.io/ipfs/${cid}` }</Link>
           </div>
-          <Button translationId="buttonLearnMore" href="https://github.com/ipfs/js-ipfs/tree/master/examples#js-ipfs-examples-and-tutorials" />
+          <Button translationId="buttonLearnMore" href="https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs/examples#js-ipfs-examples-and-tutorials" />
         </div>
       </div>
     )

--- a/src/shared/components/nav-bar/desktop/index.js
+++ b/src/shared/components/nav-bar/desktop/index.js
@@ -18,7 +18,7 @@ class DesktopNavBar extends Component {
       <div className={ navBarClasses } >
         <div className={ styles.navBarMenu }>
           <div className={ styles.link } onClick={ this.handleGettingStartedClick }> { messages.navBar.item1 } </div>
-          <Link href="https://github.com/ipfs/js-ipfs/tree/master/examples#js-ipfs-examples-and-tutorials">
+          <Link href="https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs/examples#js-ipfs-examples-and-tutorials">
             { messages.navBar.item2 }
           </Link>
           <Link href="https://github.com/ipfs/interface-js-ipfs-core/tree/master/SPEC">

--- a/src/shared/components/nav-bar/mobile/index.js
+++ b/src/shared/components/nav-bar/mobile/index.js
@@ -43,7 +43,7 @@ class MobileNavBar extends Component {
         </div>
         <ul className={ styles.menuList } ref={ this.handleMenuListRef } style={ { maxHeight: menuListHeight } } >
           <li><div className={ styles.menuLink } onClick={ this.handleGettingStartedClick }> { messages.navBar.item1 } </div> </li>
-          <li><Link className={ styles.menuLink } href="https://github.com/ipfs/js-ipfs/tree/master/examples#js-ipfs-examples-and-tutorials"> { messages.navBar.item2 } </Link> </li>
+          <li><Link className={ styles.menuLink } href="https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs/examples#js-ipfs-examples-and-tutorials"> { messages.navBar.item2 } </Link> </li>
           <li><Link className={ styles.menuLink } href="https://github.com/ipfs/interface-js-ipfs-core/tree/master/SPEC"> { messages.navBar.item3 } </Link> </li>
           <li className={ styles.githubContributers }>
             <Link className={ styles.menuLink } href="https://github.com/ipfs/js-ipfs"> { messages.navBar.item4 } </Link>


### PR DESCRIPTION
The examples have moved inside the js-ipfs repo, links updated to the new location