### PR TITLE
fix: sanbox iframe with github star count

### DIFF
--- a/src/shared/components/nav-bar/desktop/index.js
+++ b/src/shared/components/nav-bar/desktop/index.js
@@ -28,7 +28,7 @@ class DesktopNavBar extends Component {
             { messages.navBar.item4 }
           </Link>
           <div className={ styles.starContainer }>
-            <iframe title="desktop-github-stars" src="https://ghbtns.com/github-btn.html?user=ipfs&repo=js-ipfs&type=star&count=true" frameBorder="0" scrolling="0"/>
+            <iframe title="desktop-github-stars" src="https://ghbtns.com/github-btn.html?user=ipfs&repo=js-ipfs&type=star&count=true" frameBorder="0" scrolling="0" sandbox="allow-scripts" />
           </div>
         </div>
       </div>

--- a/src/shared/components/nav-bar/mobile/index.js
+++ b/src/shared/components/nav-bar/mobile/index.js
@@ -47,7 +47,7 @@ class MobileNavBar extends Component {
           <li><Link className={ styles.menuLink } href="https://github.com/ipfs/js-ipfs/tree/master/docs/core-api"> { messages.navBar.item3 } </Link> </li>
           <li className={ styles.githubContributers }>
             <Link className={ styles.menuLink } href="https://github.com/ipfs/js-ipfs"> { messages.navBar.item4 } </Link>
-            <iframe title="mobile-github-stars" src="https://ghbtns.com/github-btn.html?user=ipfs&repo=js-ipfs&type=star&count=true" frameBorder="0" scrolling="0"/>
+            <iframe title="mobile-github-stars" src="https://ghbtns.com/github-btn.html?user=ipfs&repo=js-ipfs&type=star&count=true" frameBorder="0" scrolling="0" sandbox="allow-scripts" />
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Better safe than sorry: this PR isolates the third-party iframe from js.ipfs.io Origin.

Ref. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe