### PR TITLE
feat(i18n): add ja-JP, cs and ca

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -6,6 +6,6 @@ file_filter = intl/messages/<lang>.json
 minimum_perc = 100
 source_file = intl/messages/en.json
 source_lang = en
-lang_map = zh_CN: zh-CN, zh_HK: zh-HK, zh_TW: zh-TW, ko_KR: ko-KR, pt_PT: pt-PT, pt_BR: pt-BR
+lang_map = zh_CN: zh-CN, zh_HK: zh-HK, zh_TW: zh-TW, ko_KR: ko-KR, ja_JP: ja-JP, pt_PT: pt-PT, pt_BR: pt-BR
 type = KEYVALUEJSON
 

--- a/intl/config.js
+++ b/intl/config.js
@@ -8,7 +8,10 @@ module.exports = {
     { acronym: 'da', fullForm: 'Dansk' },
     { acronym: 'fr', fullForm: 'Français' },
     { acronym: 'pt', fullForm: 'Português' },
+    { acronym: 'cs', fullForm: 'Český' },
+    { acronym: 'ca', fullForm: 'Català' },
     { acronym: 'zh-CN', fullForm: '简体中文' },
-    { acronym: 'ko-KR', fullForm: '한국어' }
+    { acronym: 'ko-KR', fullForm: '한국어' },
+    { acronym: 'ja-JP', fullForm: '日本語' }
   ]
 }

--- a/intl/messages/ca.json
+++ b/intl/messages/ca.json
@@ -1,0 +1,157 @@
+{
+  "notFoundPage": {
+    "mainMessage": "No s'ha trobat la pàgina",
+    "detailedMessage": "Quina tristor... has seguit una ruta que no existeix."
+  },
+  "buttons": {
+    "buttonLearnMore": "Saber-ne més",
+    "buttonGithub": "Github",
+    "buttonTwitter": "Twitter",
+    "buttonIrcFreenode": "Freenode IRC",
+    "buttonAddLanguage": "Afegir el teu idioma"
+  },
+
+  "navBar": {
+    "item1": "Inicia-t'hi",
+    "item2": "Tutorials",
+    "item3": "API",
+    "item4": "Codi Obert"
+  },
+
+  "hero": {
+    "welcomeMessage": {
+      "long": "Un protocol P2P complet escrit íntegrament en Javascript",
+      "short": "Un protocol P2P en Javascript"
+    },
+    "textDescription": {
+      "long": "js-ipfs aplana el camí al Navegador per implementar el protocol IPFS. Escrit íntegrament en JavaScript, funciona al Navegador, com a Service Worker, com a Extensió de Navegador i a Node.js. Això obre les portes a un tot un món de possibilitats.",
+      "short": "js-ipfs funciona al Navegador, com a Service Worker, com a Extensió de Navegador i amb Node.js. Això obre les portes a un tot un món de possibilitats."
+    },
+    "currentVersion": {
+      "long": "Versió actual: {version}",
+      "short": "v{version}"
+      },
+    "latestUpdate": {
+      "long": "Última actualització: {date}",
+      "short": "Actualitzat {date}"
+      },
+    "downloadsLastMonth": "Descàrregues durant el mes passat: {count}",
+    "errorPckMessage": "No s'ha pogut aconseguir el paquet d'informació IPFS",
+    "animationButton": {
+      "enable": "Activar Animació",
+      "disable": "Desactivar Animació"
+    }
+  },
+
+  "banner": {
+    "highlightMessage": "La llibreria js-ipfs està en estat Alpha",
+    "message": "El codi no ha estat auditat per experts en seguretat i no s'hauria d'utilitzar per emmagatzemar, compartir o publicar informació delicada."
+  },
+
+  "features": {
+    "sectionTitle": "Prestacions",
+    "sectionDesc": "Inclout totes les coses que coneixes i t'agraden de l'IPFS. Aquesta implementació també porta algunes coses extra que són pròpies del Navegador. És la caixa d'eines per potenciar totes les teves Aplicacions DWeb.",
+    "list": [
+      {
+        "title": "Funciona amb Node.js i al Navegador",
+        "desc": "js-ipfs funciona amb Node.js, Electron i qualsevol navegador modern. A més, és costumitzable per naturalesa i el pots utilitzar en el teu entorn preferit."
+      },
+      {
+        "title": "Implementa tot l'Stack IPFS",
+        "desc": "Cap prestació ha quedat enrere. js-ipfs no és un client lleuger, és la implementació íntegra del protocol IPFS."
+      },
+      {
+        "title": "Utilitza PubSub per comunicar-te amb altres peers en temps real.",
+        "desc": "Els node IPFS poden crear topologies de xarxa basades en temes d'interès per emetre esdeveniments a temps real."
+      },
+      {
+        "title": "Afegeix i aconsegueix arxius de qualsevol lloc de la Xarxa IPFS",
+        "desc": "IPFS ha estat dissenyar utilitzar la potencia del Direccionament per Contingut per trobar nodes a la xarxa que tinguin el contingut que s'està cercant. Així mateix, pots afegir dades i altres nodes també el trobaran."
+      },
+      {
+        "title": "Utilitza l'API DAG per explorar qualsevol hash d'estructura encadenada d'informació",
+        "desc": "IPFS utilitza [IPLD](https://ipld.io/), InterPlanetary Linked-Data, un model que et permet interactuar amb informació procedent de diversos llocs, com git, blockchains i altres."
+      },
+      {
+        "title": "libp2p hi està incorporat",
+        "desc": "[libp2p](https://libp2p.io/)  és l'Stack Modular per Networking creat per IPFS i que ara pots utilitzar directament a la teva aplicació a través de l'IPFS."
+      },
+      {
+        "title": "Executa'l com un procés ",
+        "desc": "js-ipfs també ve amb l'opció de funcionar com a procés de fons. Així hi pots interactuar amb l'API HTTP que ja coneixes del go-ifps. "
+      },
+      {
+        "title": "Crea direccions estables per l'intercanvi d'informació",
+        "desc": "Inclou IPNS, l'Interplanetary Naming System, una manera de crear apuntadors mutables (registres) per distribuir actualitzacions d'una manera autenticada i certificada."
+      }
+    ]
+  },
+
+  "gettingStarted": {
+    "sectionTitle": "Com Començar",
+    "sectionDesc": "IPFS t'ofereix un primitiu de Direcionament per Contingut per totes les teves dades a la DWeb. Pots fer les teves dades accessibles a la xarxa o accedir a informació existent per mitjà del seu CID, el Content Identifier; Identificador de Contingut en anglès. Prova-ho aquí a sota o explora els nostres [ProtoSchool tutorials](https://proto.school/#/tutorials)!",
+    "addDataToIPFS": "Afegir informació a l'IPFS",
+    "output": "Sortida",
+    "getDataFromIPFS": "Aconseguir informació de l'IPFS",
+    "usingJavascript": "Utilitzant Javascript al Navegador o Node.js",
+    "usingCli": "Fer servir la CLI",
+    "usingGateway": "Fer servir el Gateway HTTP"
+  },
+
+  "serviceWorker": {
+    "sectionTitle": "Gateway del Service Worker",
+    "sectionDesc": "Converteix aquesta pàgina en un Gateway IPFS complet sense tocar cap servidor o fes servir HTTP per aconseguir contingut de la xarxa IPFS! Sï, ho has llegit bé, el Service Worker Gateway    amb el js-ipfs pot connectar directament a la xarxa IPFS.",
+    "activationSuccessTitle": "Enhorabona! El teu navegador ja és un Gateway IPFS plenament operacional.",
+    "activationSuccessText": "Carrega qualsevol contingut tal i com ho faries normalment amb https://gateway.ipfs.io. Aquí tens alguns exemples que pots provar: \n- [ipfs.io - /ipfs/{ipfsWebsiteHash}](https://js.ipfs.io/ipfs/{ipfsWebsiteHash})\n- [js.ipfs.io - /ipfs/{jsIpfsWebsiteHash}](https://js.ipfs.io/ipfs/{jsIpfsWebsiteHash})\n- [awesome.ipfs.io - /ipfs/{awesomeIpfsWebsiteHash}](https://js.ipfs.io/ipfs/{awesomeIpfsWebsiteHash})\n - [peerpad.net - /ipfs/{peerpadWebsiteHash}](https://js.ipfs.io/ipfs/{peerpadWebsiteHash})\n\nProva qualsevol altres hash obrint  https://js.ipfs.io/ipfs/<your hash>",
+    "toggleText": "Activar Service Worker",
+    "activatingToggleText": "Activant Service Worker...",
+    "activationErrorMessage": "Hi ha hagut un problema mentre s'activava el Service Worker.",
+    "deactivationErrorMessage": "Hi ha hagut un problema mentre es desactivava el Service Worker.",
+    "nonRootScopeWarningMessage": "No es pot activar el Service Worker des d'aquesta URL. Prova-ho des de https://js.ipfs.io.",
+    "incompatibleMessageText": "Aquest navegador no suporta Service Workers",
+    "activatedToggleText": "Desactivar el Service Worker"
+  },
+
+  "whatArePeopleBuilding": {
+    "sectionTitle": "Què n'està construint la gent",
+    "list": [
+      {
+        "desc": "Tot l'Internet Archive però descentralitzat. Accedeix als seus 40m d'items des de la web descentralitzada,  DWeb. Això, bo i combinant un gateway de disseminació i una UI en javascript per a Firefox o Chrome."
+      },
+      {
+        "desc": "PeerPad és un editor col·laboratiu a temps real que funciona a la web descentralitzada, construïda sobre l'IPFS i Y.js. No hi ha intermediaris: Tots els nodes participants parlen directament l'un amb l'altre sense un servei central."
+      },
+      {
+        "desc": "Dota el teu Navegador de súper poders amb l'Extensió Web IPFS. L'Acompanyant IPFS és una extensió que pot ser utilitzada als navegadors Chrome, Firefox i Brave per donar-te accés a la xarxa IPFS. També inclou prestacions extra tals com la compartició d'arxius i APIs pels Desenvolupadors Web."
+      },
+      {
+        "desc": "[Orbit Chat](https://orbit.chat) és un xat serverless, distribuït i peer-to-peer construït sobre de l'OrbitDB. OrbitDB utilitza [IPFS](https://ipfs.io)  com a emmagatzematge de dades i [IPFS Pubsub](https://ipfs.io/blog/29-js-ipfs-pubsub) per sincronitzar automàticament les bases de dades amb els peers."
+      }
+    ]
+  },
+
+  "whatYouCanBuild": {
+    "sectionTitle": "Què pots construir amb JS-IPFS",
+    "sectionDesc": "Les opcions d'ús de js-ipfs són il·limitades. Amb els següents exemples pots fer-te'n una idea. Prova'ls!",
+    "suggestion": {
+      "text": "Tens suggeriments?",
+      "linkText": "Comparteix-los aquí!"
+    }
+  },
+
+  "publicationsAndTalks": {
+    "sectionTitle": "Publicacions i Conferències",
+    "sectionDesc": "Segueix les actualitzacions, demos i altres xerredes de la Comunitat IPFS sobre el projecte JavaScript d'IPFS. Anirem afegint moltes més xerrades de les Dev Meetings de IPFS."
+  },
+
+  "community": {
+    "sectionTitle": "Comunitat",
+    "sectionDesc": "js-ipfs és un projecte de Codi Obert de la comunitat IPFS subjecta a la llicència MIT. Pots contribuir-hi de diverses maneres: Ajuda a escriure especificacions, implementa eines que utilitzin js-ipfs, crea exemples i tutorials i uneix-te al nostre [grup de treball](https://github.com/ipfs/team-mgmt#synchronous-communication) per debatre l'IPFS amb nosaltres.",
+    "socialNetworksText": "Vine i troba'ns!"
+  },
+
+  "footer": {
+    "rightContent": "js-ipfs va ser iniciat i patrocinat per",
+    "leftContent": "Protocol Labs | Si no s'especifica el contrari, contingut llicenciat sota CC-BY 3.0"
+  }
+}

--- a/intl/messages/cs.json
+++ b/intl/messages/cs.json
@@ -1,0 +1,157 @@
+{
+  "notFoundPage": {
+    "mainMessage": "Stránka nenalezena",
+    "detailedMessage": "Právě jste narazili na trasu, která neexistuje... to je smutné."
+  },
+  "buttons": {
+    "buttonLearnMore": "Více informací",
+    "buttonGithub": "GitHub",
+    "buttonTwitter": "Twitter",
+    "buttonIrcFreenode": "IRC Freenode",
+    "buttonAddLanguage": "Přidejte svůj jazyk"
+  },
+
+  "navBar": {
+    "item1": "Začít",
+    "item2": "Návody",
+    "item3": "API",
+    "item4": "Open Source"
+  },
+
+  "hero": {
+    "welcomeMessage": {
+      "long": "Úplný protokol P2P napsaný výhradně v jazyce JavaScript",
+      "short": "P2P JavaScript protokol"
+    },
+    "textDescription": {
+      "long": "js-ipfs připravuje cestu pro implementaci protokolu IPFS prohlížeči. Napsáno výhradně v JavaScriptu, běží v prohlížeči, v Servise Workeru, ve webovém rozšíření a v Node.js a otevírá dveře do světa možností.",
+      "short": "js-ipfs běží v prohlížeči, v Service Workeru, ve webovém rozšíření a v Node.js, což otevírá dveře do světa možností."
+    },
+    "currentVersion": {
+      "long": "Aktuální verze: {version}",
+      "short": "v{version}"
+      },
+    "latestUpdate": {
+      "long": "Poslední aktualizace: {date}",
+      "short": "Aktualizováno {date}"
+      },
+    "downloadsLastMonth": "Stažení za poslední měsíc: {count}",
+    "errorPckMessage": "Data balíčku IPFS se nepodařilo načíst.",
+    "animationButton": {
+      "enable": "Povolit animace",
+      "disable": "Zakázat animace"
+    }
+  },
+
+  "banner": {
+    "highlightMessage": "Knihovna js-ipfs je ve stavu Alpha.",
+    "message": "Codebase nebyl auditován bezpečnostními specialisty a neměl by být používán k ukládání, sdílení nebo publikování citlivých informací."
+  },
+
+  "features": {
+    "sectionTitle": "Funkce",
+    "sectionDesc": "Balíček se všemi věcmi, které znáte a milujete o IPFS. Tato implementace také přináší některé další elegantní věci, které jsou jedinečné pro prohlížeč. Je to sada nástrojů k napájení všech vašich aplikací DWeb.",
+    "list": [
+      {
+        "title": "Běží na Node.js a v prohlížeči",
+        "desc": "js-ipfs funguje na Node.js, Electronu a jakémkoli moderním prohlížeči. Je také přizpůsobitelný podle návrhu, takže jej můžete použít ve své oblíbeném runtime."
+      },
+      {
+        "title": "Implementuje plný zásobník IPFS",
+        "desc": "Nezůstala žádná funkce. js-ipfs není lehký klient, jedná se o plnou implementaci protokolu IPFS."
+      },
+      {
+        "title": "Pomocí PubSub můžete komunikovat v reálném čase s ostatními uzly",
+        "desc": "Uzly IPFS mohou vytvářet topologie sítí na základě témat, která jsou předmětem zájmu o vysílání událostí v reálném čase."
+      },
+      {
+        "title": "Přidejte a načtěte soubory odkudkoli v síti IPFS",
+        "desc": "IPFS je navržen tak, aby využíval sílu adresování obsahu k nalezení uzlů v síti, které mají hledaný obsah. Stejným způsobem můžete přidávat data a další uzly je také najdou."
+      },
+      {
+        "title": "Pomocí rozhraní DAG API můžete procházet jakoukoli zahashovanou strukturu spojených dat",
+        "desc": "IPFS používá [IPLD] (https://ipld.io/), InterPlanetary Linked-Data, model, který umožňuje interakci s daty z více zdrojů, jako jsou git, blockchains a další."
+      },
+      {
+        "title": "libp2p je vestavěn",
+        "desc": "[libp2p] (https://libp2p.io/) je Modular Networking Stack, který byl vytvořen pro IPFS a nyní jej můžete přímo používat také prostřednictvím IPFS pro vaši aplikaci."
+      },
+      {
+        "title": "Spusťte ho jako démona",
+        "desc": "js-ipfs také přichází s možností spustit ho jako démona, takže s ní můžete komunikovat pomocí HTTP API, které znáte z go-ipfs."
+      },
+      {
+        "title": "Vytvořte stabilní adresy pro změnu dat",
+        "desc": "Dodává se s IPNS, meziplanetárním jmenným systémem, což je způsob, jak autorizovat proměnné ukazatele (záznamy) pro distribuci aktualizací autentizovaným a certifikovaným způsobem."
+      }
+    ]
+  },
+
+  "gettingStarted": {
+    "sectionTitle": "Začínáme",
+    "sectionDesc": "IPFS vám dává primitivní řešení pro všechna vaše data na DWebu. Data můžete zpřístupnit do sítě nebo načíst stávající data prostřednictvím svého CID, identifikátoru obsahu. Vyzkoušejte to níže nebo si prohlédněte naše [ProtoSchool návody] (https://proto.school/#/tutorials)!",
+    "addDataToIPFS": "Přidávám data do IPFS",
+    "output": "Výstup",
+    "getDataFromIPFS": "Získávám data z IPFS",
+    "usingJavascript": "Použití Javascriptu v prohlížeči nebo Node.js",
+    "usingCli": "Pomocí CLI",
+    "usingGateway": "Používání brány HTTP"
+  },
+
+  "serviceWorker": {
+    "sectionTitle": "Brána Service Workeru",
+    "sectionDesc": "Proměňte tuto stránku v úplnou bránu IPFS, aniž byste se dotkli jakýchkoli serverů nebo pomocí protokolu HTTP načtěte obsah ze sítě IPFS! Ano, čtete to správně, služba Service Worker Gateway s js-ipfs se může připojit přímo k síti IPFS.",
+    "activationSuccessTitle": "Gratulujeme! Váš prohlížeč je nyní plně funkční bránou IPFS",
+    "activationSuccessText": "Načtěte veškerý obsah, jak byste normálně dělali s https://gateway.ipfs.io. Zde je několik příkladů, které můžete vyzkoušet:\n- [ipfs.io - /ipfs/{ipfsWebsiteHash}](https://js.ipfs.io/ipfs/{ipfsWebsiteHash})\n- [js.ipfs.io - /ipfs/{jsIpfsWebsiteHash}](https://js.ipfs.io/ipfs/{jsIpfsWebsiteHash})\n- [awesome.ipfs.io - /ipfs/{awesomeIpfsWebsiteHash}](https://js.ipfs.io/ipfs/{awesomeIpfsWebsiteHash})\n - [peerpad.net - /ipfs/{peerpadWebsiteHash}](https://js.ipfs.io/ipfs/{peerpadWebsiteHash})\n\nZkuste s jakýmkoli jiným hashem otevřením https://js.ipfs.io/ipfs/<your hash>",
+    "toggleText": "Povolit Service Worker",
+    "activatingToggleText": "Aktivace Service Workeru...",
+    "activationErrorMessage": "Při aktivaci Service Workeru došlo k chybě.",
+    "deactivationErrorMessage": "Při deaktivaci Service Workeru došlo k chybě.",
+    "nonRootScopeWarningMessage": "Při prohlížení z této adresy URL nelze Service Worker aktivovat. Zkuste místo toho https://js.ipfs.io.",
+    "incompatibleMessageText": "Tento prohlížeč nepodporuje Service Workery.",
+    "activatedToggleText": "Zakázat Service Worker"
+  },
+
+  "whatArePeopleBuilding": {
+    "sectionTitle": "Co s tím lidé staví",
+    "list": [
+      {
+        "desc": "Celý internetový archiv, ale decentralizovaný. Získejte přístup k více než 40m položkám archivu přes DWeb. Kombinace počáteční brány a javascript UI pro Firefox a Chrome."
+      },
+      {
+        "desc": "PeerPad je kooperativní editor v reálném čase, který pracuje na decentralizovaném webu postaveném na IPFS a Y.js. Nepoužívá druhé nebo třetí strany: všechny zúčastněné uzly mluví přímo spolu bez centrální služby."
+      },
+      {
+        "desc": "Dejte webovému prohlížeči rozšíření IPFS. IPFS Companion je rozšíření, které lze v prohlížečích Chrome, Firefox a Brave použít k bezproblémovému přístupu k síti IPFS. Obsahuje také další funkce, jako je sdílení souborů a API pro webové vývojáře."
+      },
+      {
+        "desc": "[Orbit Chat] (https://orbit.chat) je serverová, distribuovaná, peer-to-peer chatová aplikace postavená na OrbitDB. OrbitDB používá jako úložiště dat [IPFS] (https://ipfs.io) a [IPFS Pubsub] (https://ipfs.io/blog/29-js-ipfs-pubsub) pro automatickou synchronizaci databází s uzly."
+      }
+    ]
+  },
+
+  "whatYouCanBuild": {
+    "sectionTitle": "Co můžete postavit s JS-IPFS",
+    "sectionDesc": "Pro použití js-ipfs máte neomezené možnosti. Následující příklady vám poskytují představu o tom, co můžete pomocí js-ipfs vytvořit. Vyzkoušejte je!",
+    "suggestion": {
+      "text": "Máte nějaké návrhy?",
+      "linkText": "Sdílejte je zde!"
+    }
+  },
+
+  "publicationsAndTalks": {
+    "sectionTitle": "Publikace a diskuze",
+    "sectionDesc": "Sledujte aktualizace projektu, ukázky a další rozhovory komunity IPFS o projektu JavaScript IPFS. Brzy přidáme desítky dalších rozhovorů z IPFS Dev Meetings."
+  },
+
+  "community": {
+    "sectionTitle": "Komunita",
+    "sectionDesc": "js-ipfs je projekt pod MIT Licencí, Open Source projekt od komunity IPFS. Existuje mnoho způsobů, jak můžete přispět: pomozte napsat specifikaci, implementaci kódu a nástroje pomocí js-ipfs, příklady z tvorby a návody, a připojit se k našim [voláním pracovní skupiny] (https://github.com/ipfs/team-mgmt#synchronous-communication) diskutovat s námi o IPFS.",
+    "socialNetworksText": "Pojďte si zahangoutovat."
+  },
+
+  "footer": {
+    "rightContent": "js-ipfs byl založen a je sponzorován",
+    "leftContent": "Protocol Labs | Pokud není uvedeno jinak, s licencí na obsah CC-BY 3.0"
+  }
+}

--- a/intl/messages/ja-JP.json
+++ b/intl/messages/ja-JP.json
@@ -1,0 +1,157 @@
+{
+  "notFoundPage": {
+    "mainMessage": "ページがみつかりません",
+    "detailedMessage": "あなたは存在しないページに接近しました、、、悲しい"
+  },
+  "buttons": {
+    "buttonLearnMore": "もっと見る",
+    "buttonGithub": "Github",
+    "buttonTwitter": "Twitter",
+    "buttonIrcFreenode": "IRC Freenode",
+    "buttonAddLanguage": "あなたの言語を追加"
+  },
+
+  "navBar": {
+    "item1": "入門",
+    "item2": "チュートリアル",
+    "item3": "API",
+    "item4": "オープンソース"
+  },
+
+  "hero": {
+    "welcomeMessage": {
+      "long": "完全にJavascriptで書いたP2Pプロトコル",
+      "short": "P2P JavaScriptプロトコル"
+    },
+    "textDescription": {
+      "long": "js-ipfsはブラウザためにIPFSプロトコルを実現するために道を開いてくれました。完全にJavaScriptで書いて、ブラウザ、Service Worker、Webの拡張、Node.jsで実行されて、無限の可能性を見せてくれました。",
+      "short": "js-ipfsはブラウザ、Service Worker、Webの拡張、Node.jsで実行されて、無限の可能性を見せてくれました。"
+    },
+    "currentVersion": {
+      "long": "現在バージョン：{version}",
+      "short": "v{version}"
+      },
+    "latestUpdate": {
+      "long": "最近の更新: {date}",
+      "short": "{date} に更新"
+      },
+    "downloadsLastMonth": "最近一个月のダウンロード：{count}",
+    "errorPckMessage": "IPFSのページが見つかりません。",
+    "animationButton": {
+      "enable": "アニメーション有効化",
+      "disable": "アニメーション無効化"
+    }
+  },
+
+  "banner": {
+    "highlightMessage": "このjs-ipfsライブラリはAlphaバージョン。",
+    "message": "ソースコードはセキュリティ専門家による審査がなく、重要なデータは保存しなようにしてください。"
+  },
+
+  "features": {
+    "sectionTitle": "特徴",
+    "sectionDesc": "js-ipfsはあなたが知ってる、好きなIPFSの機能を全部実現してます。当時にブラウザのために特有な機能を実装し、DWebアプリケーションのためにも強力なツールを提供します。",
+    "list": [
+      {
+        "title": "Node.jsとブラウザで実行",
+        "desc": "js-ipfsはNode.js, Electronとモダンなブラウザで即時に使用できます。設計によってあなたがほしいランタイム上で使用可能です。"
+      },
+      {
+        "title": "IPFSのフルスタックを実装",
+        "desc": "実装できてない機能はありません。js-ipfsはライトなクライアントではなく、全てのIPFSプロトコルの機能をすべて実現してます。"
+      },
+      {
+        "title": "PubSubを使用して他のノードとリアルタイムで通信",
+        "desc": "IPFSノードのイベントをリアルタイムで通信するためにブロードキャストを基盤にネットワークを構成できます。"
+      },
+      {
+        "title": "IPFSネットワークのどこでもファイルを追加と検索",
+        "desc": "IPFSはあなたが探したいコンテンツを持ってるノードを見つけるためにアドレス指定可能に設定されてます。同じ方法であなたはデータを追加できて他のノードがそれを見つけることができます。"
+      },
+      {
+        "title": "DAG APIを使用して、任意のハッシュリンクされたデータ構造を横断検索",
+        "desc": "IPFSは [IPLD](https://ipld.io/) (InterPlanetary Linked-Data)を使用して、このモデルは、Git, Blockchainなど複数のデータソースと交互にやり取りすることができます。"
+      },
+      {
+        "title": "libp2p内蔵",
+        "desc": "[libp2p](https://libp2p.io/)は IPFS用に作られたModular Networking Stackで、IPFSを介して直接アプリケーションにも使えるようになっています。"
+      },
+      {
+        "title": "デーモンとして実行",
+        "desc": "js-ipfs にはデーモンとして実行するオプションもあり、go-ipfs でお馴染みの HTTP API を使って js-ipfs を操作することができます。"
+      },
+      {
+        "title": "変更されるデータに固定のアドレス",
+        "desc": "IPNS(Interplanetary Naming System)を利用し、認証済みの方式で可変ポインター（レコード）で新しい変更を反映します。"
+      }
+    ]
+  },
+
+  "gettingStarted": {
+    "sectionTitle": "入門",
+    "sectionDesc": "IPFS は、DWeb 上のすべてのデータに対して Content Addressing プリミティブを提供します。ネットワークにデータを公開したり、CID（コンテンツ識別子）を使って既存のデータを取得したりすることができます。以下で試してみたり、[ProtoSchoolチュートリアル](https://proto.school/#/tutorials)をご覧ください。",
+    "addDataToIPFS": "IPFSへのデータの追加",
+    "output": "結果出力",
+    "getDataFromIPFS": "IPFSからデータ取得",
+    "usingJavascript": "ブラウザやNode.jsでJavascriptを使う",
+    "usingCli": "CLIを使用",
+    "usingGateway": "HTTP Gatewayを使用"
+  },
+
+  "serviceWorker": {
+    "sectionTitle": "Service Workerゲートウェイ",
+    "sectionDesc": "このページをIPFSネットワークからコンテンツを取得するためにサーバーに触れたり、HTTPを使用したりすることなく、完全なIPFSゲートウェイに変身させましょう! js-ipfs を搭載した Service Worker Gateway は IPFS ネットワークに直接接続できます。",
+    "activationSuccessTitle": "おめでとうございます。お使いのブラウザが完全に動作するようになりました。",
+    "activationSuccessText": "https://gateway.ipfs.io と同様に、任意のコンテンツを読み込んでください。試してみてください:\n- [ipfs.io - /ipfs/{ipfsWebsiteHash}](https://js.ipfs.io/ipfs/{ipfsWebsiteHash})\n- [js.ipfs.io - /ipfs/{jsIpfsWebsiteHash}](https://js.ipfs.io/ipfs/{jsIpfsWebsiteHash})\n- [awesome.ipfs.io - /ipfs/{awesomeIpfsWebsiteHash}](https://js.ipfs.io/ipfs/{awesomeIpfsWebsiteHash})\n - [peerpad.net - /ipfs/{peerpadWebsiteHash}](https://js.ipfs.io/ipfs/{peerpadWebsiteHash})\n\nあなたのハッシュで試してみてください。 https://js.ipfs.io/ipfs/<あなたのハッシュ>",
+    "toggleText": "サービスワーカーを有効にする",
+    "activatingToggleText": "サービスワーカーの活性化...",
+    "activationErrorMessage": "サービスワーカーを有効にする際にエラーが発生しました。",
+    "deactivationErrorMessage": "サービスワーカーを無効にするときにエラーが発生しました。",
+    "nonRootScopeWarningMessage": "このURLからの閲覧では、サービスワーカーを有効にすることができません。代わりに https://js.ipfs.io でお試しください。",
+    "incompatibleMessageText": "このブラウザはサービスワーカーに対応していません。",
+    "activatedToggleText": "サービスワーカーを無効にする"
+  },
+
+  "whatArePeopleBuilding": {
+    "sectionTitle": "人々がそれで何を構築しているのか",
+    "list": [
+      {
+        "desc": "全体のインターネットアーカイブですが、分散化されています。DWebを介してアーカイブの4千万以上のアイテムにアクセスします。FirefoxとChrome用のjavascript UIを組み合わせています。"
+      },
+      {
+        "desc": "PeerPadは、IPFSとY.jsの上に構築された、分散型ウェブ上で動作するリアルタイムの共同エディタです。参加するすべてのノードは、中央のサービスを介さずに直接通信します。"
+      },
+      {
+        "desc": "IPFS ウェブ拡張機能でブラウザに超強力なパワーを与えましょう。IPFS Companion は、Chrome、Firefox、Brave Browsers で使用できる拡張機能で、IPFS ネットワークにシームレスにアクセスできます。また、Web 開発者向けのファイル共有や API などの追加機能も搭載しています。"
+      },
+      {
+        "desc": "Orbit Chat](https://orbit.chat)は、OrbitDBの上に構築されたサーバーレスの分散型ピアツーピアチャットアプリケーションです。OrbitDBは、データストレージとして[IPFS](https://ipfs.io)を使用し、データベースを自動的にピアと同期するために[IPFS Pubsub](https://ipfs.io/blog/29-js-ipfs-pubsub)を使用しています。"
+      }
+    ]
+  },
+
+  "whatYouCanBuild": {
+    "sectionTitle": "JS-IPFSで構築できるもの",
+    "sectionDesc": "js-ipfsを使う方法は無限にあります。以下の例では、js-ipfsを使ってどんなものが作れるかを紹介しています。ぜひ試してみてください。",
+    "suggestion": {
+      "text": "アイディアと提案はありますか？",
+      "linkText": "ここで共有しましょう！"
+    }
+  },
+
+  "publicationsAndTalks": {
+    "sectionTitle": "出版物と講演",
+    "sectionDesc": "IPFS の JavaScript プロジェクトに関する IPFS コミュニティによるプロジェクトのアップデート、デモ、その他のトークをご覧ください。IPFS Dev Meetings で行われた講演を近日中に追加する予定です。"
+  },
+
+  "community": {
+    "sectionTitle": "コミュニティ",
+    "sectionDesc": "js-ipfs は IPFS コミュニティによる MIT ライセンスのオープンソースプロジェクトです。貢献できる方法はたくさんあります: 仕様書の作成、js-ipfs を使った実装やツールのコード作成、サンプルやチュートリアルの作成、私たちの [ワーキンググループコール](https://github.com/ipfs/team-mgmt#synchronous-communication) に参加して IPFS について議論してください。",
+    "socialNetworksText": "参加しましょう！"
+  },
+
+  "footer": {
+    "rightContent": "js-ipfs が開始時以下のスポンサーによって応援されてます。",
+    "leftContent": "Protocol Labs｜特に記載のない限り、コンテンツはCC-BY 3.0でライセンスされています。"
+  }
+}

--- a/src/shared/components/locales-bar/index.js
+++ b/src/shared/components/locales-bar/index.js
@@ -27,7 +27,7 @@ const LocalesBar = ({ intl: { locale: currentLocale, messages }, className }) =>
   return (
     <div className={ localesBarClassName }>
       { renderLocales }
-      <Link className={ styles.addLanguage } href="https://github.com/ipfs/js.ipfs.io#translations">
+      <Link className={ styles.addLanguage } href="https://github.com/ipfs/js.ipfs.io#internationalization-i18n">
         <Svg svg={ iconAdd } />
         { messages.buttons.buttonAddLanguage }
       </Link>

--- a/src/shared/components/locales-dropdown/index.js
+++ b/src/shared/components/locales-dropdown/index.js
@@ -63,7 +63,7 @@ class LocalesDropdown extends Component {
         </button>
         <div className={ dropdownContentClasses }>
           { availableLocalesOptions }
-          <Link className={ styles.addLanguage } href="https://github.com/ipfs/js.ipfs.io#translations">
+          <Link className={ styles.addLanguage } href="https://github.com/ipfs/js.ipfs.io#internationalization-i18n">
             <Svg svg={ iconAdd } />
           </Link>
         </div>


### PR DESCRIPTION
This PR:

- adds new languages translated by community on Transifex  (cc #276)
  - [ja-JP](https://bafybeihopmmsakcjyd2p4mibxz5xctebuc555uraaxodjnndy2zjrdv3kq.ipfs.dweb.link/ja-JP/)
  - [cs](https://bafybeihopmmsakcjyd2p4mibxz5xctebuc555uraaxodjnndy2zjrdv3kq.ipfs.dweb.link/cs/)
  - [ca](https://bafybeihopmmsakcjyd2p4mibxz5xctebuc555uraaxodjnndy2zjrdv3kq.ipfs.dweb.link/ca/)
- fixes the link to translation instructions 

