### PR TITLE
Update tutorials nav link

### DIFF
--- a/src/shared/components/nav-bar/desktop/index.js
+++ b/src/shared/components/nav-bar/desktop/index.js
@@ -18,7 +18,7 @@ class DesktopNavBar extends Component {
       <div className={ navBarClasses } >
         <div className={ styles.navBarMenu }>
           <div className={ styles.link } onClick={ this.handleGettingStartedClick }> { messages.navBar.item1 } </div>
-          <Link href="https://github.com/ipfs/js-ipfs/tree/master/examples#js-ipfs-examples-and-tutorials">
+          <Link href="https://proto.school/#/tutorials?course=ipfs">
             { messages.navBar.item2 }
           </Link>
           <Link href="https://github.com/ipfs/js-ipfs/tree/master/docs/core-api">

--- a/src/shared/components/nav-bar/mobile/index.js
+++ b/src/shared/components/nav-bar/mobile/index.js
@@ -43,7 +43,7 @@ class MobileNavBar extends Component {
         </div>
         <ul className={ styles.menuList } ref={ this.handleMenuListRef } style={ { maxHeight: menuListHeight } } >
           <li><div className={ styles.menuLink } onClick={ this.handleGettingStartedClick }> { messages.navBar.item1 } </div> </li>
-          <li><Link className={ styles.menuLink } href="https://github.com/ipfs/js-ipfs/tree/master/examples#js-ipfs-examples-and-tutorials"> { messages.navBar.item2 } </Link> </li>
+          <li><Link className={ styles.menuLink } href="https://proto.school/#/tutorials?course=ipfs"> { messages.navBar.item2 } </Link> </li>
           <li><Link className={ styles.menuLink } href="https://github.com/ipfs/js-ipfs/tree/master/docs/core-api"> { messages.navBar.item3 } </Link> </li>
           <li className={ styles.githubContributers }>
             <Link className={ styles.menuLink } href="https://github.com/ipfs/js-ipfs"> { messages.navBar.item4 } </Link>


### PR DESCRIPTION
This PR changes the Tutorials link in desktop and mobile versions of the js.ipfs.io nav to direct to the new IPFS course on ProtoSchool (a filtered list of tutorials related to IPFS, where all coding challenges are js-ipfs coding challenges) rather than the directory of examples and tutorials at https://github.com/ipfs/js-ipfs/tree/master/examples#js-ipfs-examples-and-tutorials. (That directory remains linked from the Learn More button.)

Per my discussion with @johnnymatthews, this is intended as a temporary fix for the next few weeks while the examples in that directory are ported to docs.ipfs.io where the structure will then look something like this: 

```
Integrations
	Go-IPFS
		...
	JS-IPFS
		Install
		Features
		**Tutorials**
			<ALL THE EXAMPLES FROM ipfs/js-ipfs>
                         ProtoSchool --> (external link)
	Rust-IPFS
		...
```

Once that happens, the intent is to change this Tutorials nav link to lead to the new tutorials section of the js-ipfs docs there, where visitors will be able to find both the tutorials that currently live in the js-ipfs examples folder and those that live on ProtoSchool. 

@achingbrain just confirming this sounds temporary change is okay with you?