### PR TITLE
Updated Twitter link to active IPFS account.

### DIFF
--- a/src/shared/components/community-section/index.js
+++ b/src/shared/components/community-section/index.js
@@ -34,7 +34,7 @@ class Community extends Component {
               <div className={ styles.socialLinks }>
                 <Button translationId="buttonIrcFreenode" href="http://webchat.freenode.net/?channels=%23ipfs" />
                 <Button translationId="buttonGithub" href="https://github.com/ipfs/js-ipfs" modifier="github" />
-                <Button translationId="buttonTwitter" href="https://twitter.com/ipfsbot" modifier="twitter" />
+                <Button translationId="buttonTwitter" href="https://twitter.com/IPFS" modifier="twitter" />
               </div>
             </div>
           </div>


### PR DESCRIPTION
The old link was pointed to a Twitter account that just has a post pointing to the new one.

Figure it makes sense to just point to the active account.